### PR TITLE
Open links in new tab instead

### DIFF
--- a/apps/web/src/app/presentation/components/SlideCard.tsx
+++ b/apps/web/src/app/presentation/components/SlideCard.tsx
@@ -12,7 +12,12 @@ interface SlideCardProps {
 
 export default function SlideCard({ href, title, children }: SlideCardProps) {
 	return (
-		<Link href={href} style={{ textDecoration: "none", color: "inherit" }}>
+		<Link
+			href={href}
+			target="_blank"
+			rel="noopener noreferrer"
+			style={{ textDecoration: "none", color: "inherit" }}
+		>
 			<div
 				style={{
 					border: "1px solid #ccc",


### PR DESCRIPTION
SlideCardコンポーネントのLinkにtarget="_blank"を追加し、
一覧ページからスライドを開く際に新しいタブで開くように変更