### PR TITLE
Optimize slide loading and navigation on mobile

### DIFF
--- a/apps/web/src/app/presentation/buri/layout.tsx
+++ b/apps/web/src/app/presentation/buri/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
 	title: "buri | mySlides",
@@ -15,18 +15,26 @@ export const metadata: Metadata = {
 	},
 };
 
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	maximumScale: 1,
+	userScalable: false,
+};
+
 export default function Layout({ children }: { children: React.ReactNode }) {
 	return (
 		<div
 			style={{
 				width: "100%",
-				height: "100vh",
+				height: "100dvh",
 				overflow: "hidden",
 				position: "fixed",
 				top: 0,
 				left: 0,
 				right: 0,
 				bottom: 0,
+				touchAction: "pan-x pan-y",
 			}}
 		>
 			{children}

--- a/apps/web/src/app/presentation/components/SlideCard.tsx
+++ b/apps/web/src/app/presentation/components/SlideCard.tsx
@@ -2,6 +2,7 @@
 
 import type { Route } from "next";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import RevealPresentation from "@/components/reveal-presentation";
 
 interface SlideCardProps {
@@ -11,6 +12,33 @@ interface SlideCardProps {
 }
 
 export default function SlideCard({ href, title, children }: SlideCardProps) {
+	const cardRef = useRef<HTMLDivElement>(null);
+	const [isVisible, setIsVisible] = useState(false);
+
+	useEffect(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				entries.forEach((entry) => {
+					if (entry.isIntersecting) {
+						setIsVisible(true);
+						// 一度表示されたらObserverを解除
+						observer.disconnect();
+					}
+				});
+			},
+			{
+				rootMargin: "100px", // 100px手前でプリロード開始
+				threshold: 0,
+			},
+		);
+
+		if (cardRef.current) {
+			observer.observe(cardRef.current);
+		}
+
+		return () => observer.disconnect();
+	}, []);
+
 	return (
 		<Link
 			href={href}
@@ -19,6 +47,7 @@ export default function SlideCard({ href, title, children }: SlideCardProps) {
 			style={{ textDecoration: "none", color: "inherit" }}
 		>
 			<div
+				ref={cardRef}
 				style={{
 					border: "1px solid #ccc",
 					borderRadius: "8px",
@@ -29,7 +58,23 @@ export default function SlideCard({ href, title, children }: SlideCardProps) {
 				}}
 			>
 				<div style={{ aspectRatio: "16/9", position: "relative" }}>
-					<RevealPresentation embedded>{children}</RevealPresentation>
+					{isVisible ? (
+						<RevealPresentation embedded>{children}</RevealPresentation>
+					) : (
+						<div
+							style={{
+								width: "100%",
+								height: "100%",
+								background: "#1a1a1a",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								color: "#666",
+							}}
+						>
+							Loading...
+						</div>
+					)}
 				</div>
 				<div style={{ padding: "1rem", background: "#fff" }}>
 					<h3 style={{ margin: 0, color: "#333" }}>{title}</h3>

--- a/apps/web/src/app/presentation/sample/layout.tsx
+++ b/apps/web/src/app/presentation/sample/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
 	title: "Welcome to My Slides | mySlides",
@@ -18,18 +18,26 @@ export const metadata: Metadata = {
 	},
 };
 
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	maximumScale: 1,
+	userScalable: false,
+};
+
 export default function Layout({ children }: { children: React.ReactNode }) {
 	return (
 		<div
 			style={{
 				width: "100%",
-				height: "100vh",
+				height: "100dvh",
 				overflow: "hidden",
 				position: "fixed",
 				top: 0,
 				left: 0,
 				right: 0,
 				bottom: 0,
+				touchAction: "pan-x pan-y",
 			}}
 		>
 			{children}

--- a/apps/web/src/app/presentation/sencorp/layout.tsx
+++ b/apps/web/src/app/presentation/sencorp/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
 	title: "Sencorp | mySlides",
@@ -15,18 +15,26 @@ export const metadata: Metadata = {
 	},
 };
 
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	maximumScale: 1,
+	userScalable: false,
+};
+
 export default function Layout({ children }: { children: React.ReactNode }) {
 	return (
 		<div
 			style={{
 				width: "100%",
-				height: "100vh",
+				height: "100dvh",
 				overflow: "hidden",
 				position: "fixed",
 				top: 0,
 				left: 0,
 				right: 0,
 				bottom: 0,
+				touchAction: "pan-x pan-y",
 			}}
 		>
 			{children}

--- a/apps/web/src/app/presentation/spurs/layout.tsx
+++ b/apps/web/src/app/presentation/spurs/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
 	title: "Welcome to spurs | mySlides",
@@ -18,18 +18,26 @@ export const metadata: Metadata = {
 	},
 };
 
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	maximumScale: 1,
+	userScalable: false,
+};
+
 export default function Layout({ children }: { children: React.ReactNode }) {
 	return (
 		<div
 			style={{
 				width: "100%",
-				height: "100vh",
+				height: "100dvh",
 				overflow: "hidden",
 				position: "fixed",
 				top: 0,
 				left: 0,
 				right: 0,
 				bottom: 0,
+				touchAction: "pan-x pan-y",
 			}}
 		>
 			{children}

--- a/apps/web/src/app/presentation/tacos/layout.tsx
+++ b/apps/web/src/app/presentation/tacos/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
 	title: "Welcome to My Slides | mySlides",
@@ -18,18 +18,26 @@ export const metadata: Metadata = {
 	},
 };
 
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	maximumScale: 1,
+	userScalable: false,
+};
+
 export default function Layout({ children }: { children: React.ReactNode }) {
 	return (
 		<div
 			style={{
 				width: "100%",
-				height: "100vh",
+				height: "100dvh",
 				overflow: "hidden",
 				position: "fixed",
 				top: 0,
 				left: 0,
 				right: 0,
 				bottom: 0,
+				touchAction: "pan-x pan-y",
 			}}
 		>
 			{children}

--- a/apps/web/src/components/reveal-presentation.tsx
+++ b/apps/web/src/components/reveal-presentation.tsx
@@ -57,6 +57,19 @@ export default function RevealPresentation({
 				// embeddedモード時はコントロールを非表示
 				controls: !embedded,
 				progress: !embedded,
+
+				// モバイル最適化設定
+				touch: true, // タッチナビゲーションを明示的に有効化
+				hideAddressBar: true, // モバイルでアドレスバーを隠す
+
+				// パフォーマンス最適化
+				viewDistance: embedded ? 1 : 3, // プリロードするスライド数
+				mobileViewDistance: embedded ? 1 : 2, // モバイル向けのプリロード数
+
+				// ナビゲーション設定
+				navigationMode: "linear", // モバイルで使いやすいリニアナビゲーション
+				disableLayout: embedded, // embeddedモードではレイアウト計算を無効化
+
 				...config,
 			});
 


### PR DESCRIPTION
- reveal.jsにモバイル最適化設定を追加
  - touch: trueでタッチナビゲーションを明示的に有効化
  - viewDistance/mobileViewDistanceでプリロード数を最適化
  - navigationMode: linearでモバイル向けナビゲーション
  - hideAddressBar: trueでモバイルアドレスバーを非表示

- SlideCardにIntersection Observerを追加
  - ビューポートに入るまでReveal.js初期化を遅延
  - 一覧ページの初期読み込みパフォーマンスを改善

- 各プレゼンテーションレイアウトにviewport設定を追加
  - モバイルでのピンチズームを無効化
  - 100dvhで正確なビューポート高さを使用
  - touchActionでスワイプナビゲーションを許可