### PR TITLE
Update dotfiles presentation metadata and OG image

### DIFF
--- a/apps/web/src/app/you-must-have-dotfiles/layout.tsx
+++ b/apps/web/src/app/you-must-have-dotfiles/layout.tsx
@@ -1,20 +1,21 @@
 import type { Metadata, Viewport } from "next";
 
 export const metadata: Metadata = {
-	title: "you-must-have-dotfiles | mySlides",
+	title:
+		"Vim使いでなくてもdotfilesを管理しよう | Yoriai.cafe 二日間限定オープン！",
 	description:
-		"you-must-have-dotfiles - A presentation created with mySlides and Reveal.js",
+		"Yoriai.cafe 二日間限定オープン！ 🍛ホタテカレーと出会いの「寄り合い」での発表資料 - dotfiles管理の重要性と始め方を紹介します",
 	openGraph: {
-		title: "you-must-have-dotfiles",
+		title: "Vim使いでなくてもdotfilesを管理しよう",
 		description:
-			"you-must-have-dotfiles - A presentation created with mySlides and Reveal.js",
+			"Yoriai.cafe 二日間限定オープン！ での発表資料 by ぶりお @burio_16",
 		type: "website",
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "you-must-have-dotfiles",
+		title: "Vim使いでなくてもdotfilesを管理しよう",
 		description:
-			"you-must-have-dotfiles - A presentation created with mySlides and Reveal.js",
+			"Yoriai.cafe 二日間限定オープン！ での発表資料 by ぶりお @burio_16",
 	},
 };
 

--- a/apps/web/src/app/you-must-have-dotfiles/opengraph-image.tsx
+++ b/apps/web/src/app/you-must-have-dotfiles/opengraph-image.tsx
@@ -1,6 +1,8 @@
 import { ImageResponse } from "next/og";
 
-export const alt = "you-must-have-dotfiles";
+const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
+
+export const alt = "Vim使いでなくてもdotfilesを管理しよう";
 export const size = {
 	width: 1200,
 	height: 630,
@@ -21,7 +23,7 @@ export default function Image() {
 		>
 			{/* biome-ignore lint/performance/noImgElement: next/og ImageResponseではimg要素が必要 */}
 			<img
-				src="https://pub-12dea38316b14a799f73d17465eadeb1.r2.dev/外部登壇資料テンプレ/千_外部登壇スライド_表紙.png"
+				src={`${R2_BASE}/外部登壇資料テンプレ/千_外部登壇スライド_表紙.png`}
 				alt="スライド表紙"
 				style={{
 					position: "absolute",
@@ -32,6 +34,69 @@ export default function Image() {
 					objectFit: "cover",
 				}}
 			/>
+			{/* 表紙と同じテキストオーバーレイ */}
+			<div
+				style={{
+					position: "absolute",
+					top: 0,
+					left: 0,
+					width: "100%",
+					height: "100%",
+					display: "flex",
+					flexDirection: "column",
+					justifyContent: "center",
+					padding: "0 60px",
+				}}
+			>
+				<p
+					style={{
+						fontSize: 32,
+						fontWeight: 700,
+						color: "#fff",
+						margin: 0,
+					}}
+				>
+					Yoriai.cafe 二日間限定オープン！ 🍛ホタテカレーと出会いの「寄り合い」
+				</p>
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						margin: "24px 0",
+					}}
+				>
+					<span
+						style={{
+							fontSize: 56,
+							fontWeight: 700,
+							color: "#fff",
+							lineHeight: 1.3,
+						}}
+					>
+						Vim使いでなくても
+					</span>
+					<span
+						style={{
+							fontSize: 56,
+							fontWeight: 700,
+							color: "#fff",
+							lineHeight: 1.3,
+						}}
+					>
+						dotfilesを管理しよう
+					</span>
+				</div>
+				<p
+					style={{
+						fontSize: 32,
+						fontWeight: 700,
+						color: "#fff",
+						margin: 0,
+					}}
+				>
+					ぶりお @burio_16
+				</p>
+			</div>
 		</div>,
 		{
 			width: 1200,


### PR DESCRIPTION
## Summary
Updated metadata and Open Graph image for the "you-must-have-dotfiles" presentation to reflect the actual event details for Yoriai.cafe, a limited-time pop-up event featuring scallop curry and community gathering.

## Changes
- **Metadata updates**: Changed page title, description, and OG/Twitter card metadata from generic "you-must-have-dotfiles" to event-specific Japanese content
- **Environment variable integration**: Replaced hardcoded R2 CDN URL with `NEXT_PUBLIC_R2_BASE_URL` environment variable for better maintainability
- **OG image enhancement**: Added text overlay to the Open Graph image with:
  - Event name: "Yoriai.cafe 二日間限定オープン！ 🍛ホタテカレーと出会いの「寄り合い」"
  - Presentation title: "Vim使いでなくてもdotfilesを管理しよう" (split across two lines)
  - Speaker attribution: "ぶりお @burio_16"

## Implementation Details
- Text overlay uses flexbox layout with proper spacing and typography hierarchy
- All text is white with appropriate font sizes (32px for event/speaker info, 56px for main title)
- Maintains responsive design with padding and line-height adjustments
- Alt text updated to match the presentation title