### PR TITLE
Add MDX template slide deck for internal LT presentation

### DIFF
--- a/apps/web/src/app/mdx-template/layout.tsx
+++ b/apps/web/src/app/mdx-template/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata, Viewport } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3001";
+const SLUG = "mdx-template";
+const SLIDE_URL = `${BASE_URL}/${SLUG}`;
+
+export const metadata: Metadata = {
+	title: "LTタイトル | 社内LT会",
+	description: "2026/3/6 社内LT会での発表資料",
+	openGraph: {
+		title: "LTタイトル",
+		description: "社内LT会での発表資料 by ぶりお @burio_16",
+		type: "website",
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "LTタイトル",
+		description: "社内LT会での発表資料 by ぶりお @burio_16",
+	},
+	alternates: {
+		types: {
+			"application/json+oembed": `${BASE_URL}/api/oembed?url=${encodeURIComponent(SLIDE_URL)}&format=json`,
+		},
+	},
+};
+
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	maximumScale: 1,
+	userScalable: false,
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+	return (
+		<div className="fixed inset-0 h-dvh w-full overflow-hidden">{children}</div>
+	);
+}

--- a/apps/web/src/app/mdx-template/opengraph-image.tsx
+++ b/apps/web/src/app/mdx-template/opengraph-image.tsx
@@ -1,0 +1,95 @@
+import { ImageResponse } from "next/og";
+
+const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
+
+export const alt = "LTタイトル";
+export const size = {
+	width: 1200,
+	height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				position: "relative",
+			}}
+		>
+			{/* biome-ignore lint/performance/noImgElement: next/og ImageResponseではimg要素が必要 */}
+			<img
+				src={`${R2_BASE}/外部登壇資料テンプレ/千_外部登壇スライド_表紙.png`}
+				alt="スライド表紙"
+				style={{
+					position: "absolute",
+					top: 0,
+					left: 0,
+					width: "100%",
+					height: "100%",
+					objectFit: "cover",
+				}}
+			/>
+			<div
+				style={{
+					position: "absolute",
+					top: 0,
+					left: 0,
+					width: "100%",
+					height: "100%",
+					display: "flex",
+					flexDirection: "column",
+					justifyContent: "center",
+					padding: "0 60px",
+				}}
+			>
+				<p
+					style={{
+						fontSize: 32,
+						fontWeight: 700,
+						color: "#fff",
+						margin: 0,
+					}}
+				>
+					社内LT会
+				</p>
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						margin: "24px 0",
+					}}
+				>
+					<span
+						style={{
+							fontSize: 56,
+							fontWeight: 700,
+							color: "#fff",
+							lineHeight: 1.3,
+						}}
+					>
+						LTタイトル
+					</span>
+				</div>
+				<p
+					style={{
+						fontSize: 32,
+						fontWeight: 700,
+						color: "#fff",
+						margin: 0,
+					}}
+				>
+					ぶりお @burio_16
+				</p>
+			</div>
+		</div>,
+		{
+			width: 1200,
+			height: 630,
+		},
+	);
+}

--- a/apps/web/src/app/mdx-template/page.tsx
+++ b/apps/web/src/app/mdx-template/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import RevealPresentation from "@/components/reveal-presentation";
+import Cover from "./slides/cover";
+import SlidesContent from "./slides.mdx";
+
+export default function PresentationPage() {
+	return (
+		<div className="h-full w-full">
+			<RevealPresentation transition="slide">
+				<Cover />
+				<SlidesContent />
+			</RevealPresentation>
+		</div>
+	);
+}

--- a/apps/web/src/app/mdx-template/slides.mdx
+++ b/apps/web/src/app/mdx-template/slides.mdx
@@ -1,0 +1,59 @@
+import {
+  HeadingSlide,
+  ContentSlide,
+  CorporatePhilosophySlide,
+  BusinessContentSlide,
+  BackCoverSlide,
+} from "@/components/slides";
+import SelfIntroduction from "./slides/self-introduction";
+
+<CorporatePhilosophySlide />
+
+<BusinessContentSlide />
+
+<SelfIntroduction>
+
+- ぶりお [@burio_16](https://x.com/burio_16)
+- 千株式会社システム開発部(25卒)
+- 社内向け管理画面を開発
+- タコスとTottenham Hotspur FCが大好き
+
+</SelfIntroduction>
+
+<HeadingSlide>見出しスライドのサンプル</HeadingSlide>
+
+<ContentSlide title="コンテンツスライドのサンプル">
+
+- ここに本文を記述します
+- リスト形式で箇条書きも可能
+- MDXなのでReactコンポーネントも埋め込めます
+
+</ContentSlide>
+
+<ContentSlide title="コードブロックも使えます">
+
+```typescript
+const greeting = "Hello, World!";
+console.log(greeting);
+```
+
+</ContentSlide>
+
+<ContentSlide title="画像の埋め込み">
+  <div className="flex items-center gap-8">
+    {"説明テキストをここに"}
+    {/* <img src="/slides/mdx-template/assets/sample.png" alt="サンプル画像" className="max-w-[75%] h-auto" /> */}
+  </div>
+</ContentSlide>
+
+<HeadingSlide>まとめ</HeadingSlide>
+
+<ContentSlide title="まとめ">
+
+- ポイント1
+- ポイント2
+- ポイント3
+
+</ContentSlide>
+
+<BackCoverSlide />

--- a/apps/web/src/app/mdx-template/slides/cover.tsx
+++ b/apps/web/src/app/mdx-template/slides/cover.tsx
@@ -8,14 +8,16 @@ export default function Cover() {
 			data-background-size="contain"
 		>
 			<div className="text-left">
-				<h3>{/* イベント名をここに記入 */}</h3>
-				<br />
-				<h1 className="leading-tight">
+				<h3 className="block text-[2vw]">
+					{/* イベント名をここに記入 */}
+				</h3>
+				<h1 className="mt-[2vw] text-[3vw] leading-tight">
 					{/* タイトルをここに記入 */}
 					LTタイトル
 				</h1>
-				<br />
-				<h3>ぶりお @burio_16</h3>
+				<h3 className="mt-[12vw] text-[2vw] !text-blue-600">
+					ぶりお @burio_16
+				</h3>
 			</div>
 		</section>
 	);

--- a/apps/web/src/app/mdx-template/slides/cover.tsx
+++ b/apps/web/src/app/mdx-template/slides/cover.tsx
@@ -1,0 +1,22 @@
+const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
+const TEMPLATE_PATH = "外部登壇資料テンプレ";
+
+export default function Cover() {
+	return (
+		<section
+			data-background-image={`${R2_BASE}/${TEMPLATE_PATH}/千_外部登壇スライド_表紙.png`}
+			data-background-size="contain"
+		>
+			<div className="text-left">
+				<h3>{/* イベント名をここに記入 */}</h3>
+				<br />
+				<h1 className="leading-tight">
+					{/* タイトルをここに記入 */}
+					LTタイトル
+				</h1>
+				<br />
+				<h3>ぶりお @burio_16</h3>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/app/mdx-template/slides/self-introduction.tsx
+++ b/apps/web/src/app/mdx-template/slides/self-introduction.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
+
+interface SelfIntroductionProps {
+	children: ReactNode;
+}
+
+export default function SelfIntroduction({ children }: SelfIntroductionProps) {
+	return (
+		<section
+			data-background-image={`${R2_BASE}/外部登壇資料テンプレ/千_外部登壇スライド_本文.png`}
+			data-background-size="contain"
+		>
+			<div className="flex h-full flex-row items-center justify-evenly">
+				{/* biome-ignore lint/performance/noImgElement: Reveal.js requires img element */}
+				<img
+					src="/slides/react-three-fiber/assets/burio.png"
+					alt="ぶりおの写真"
+					className="r-stretch"
+				/>
+
+				<div className="flex flex-col">
+					<h2 className="text-black">自己紹介</h2>
+
+					<div className="space-y-2 text-left text-black md:space-y-4 lg:space-y-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6 md:[&_ul]:space-y-4 lg:[&_ul]:space-y-6">
+						{children}
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import Cover from "./better-t-stack/slides/cover";
 import R3FCover from "./react-three-fiber/slides/cover";
 import RevealCover from "./revealjs-slideDeck/slides/cover";
 import TacosCover from "./tacotuesday/slides/cover";
+import MdxTemplateCover from "./mdx-template/slides/cover";
 import YouMustHaveDotfilesCover from "./you-must-have-dotfiles/slides/cover";
 export default function Home() {
 	return (
@@ -13,6 +14,15 @@ export default function Home() {
 				Burio's slide deck
 			</h1>
 			<div className="grid grid-cols-1 gap-4 md:gap-8">
+				<SlideCard
+					href="/mdx-template"
+					title="LTタイトル"
+					date="2026/3/6"
+					event="社内LT会"
+				>
+					<MdxTemplateCover />
+				</SlideCard>
+
 				<SlideCard
 					href="/you-must-have-dotfiles"
 					title="Vim使いでなくてもdotfilesを管理しよう"

--- a/apps/web/src/lib/slides/config.ts
+++ b/apps/web/src/lib/slides/config.ts
@@ -63,6 +63,15 @@ export const SLIDES_CONFIG: Record<string, SlideConfig> = {
 		event: "Yoriai.cafe 二日間限定オープン！",
 		eventUrl: "https://peatix.com/event/4736534",
 	},
+	"mdx-template": {
+		slug: "mdx-template",
+		title: "LTタイトル",
+		description: "2026/3/6 社内LT会での発表資料",
+		author: "ぶりお",
+		authorUrl: "https://twitter.com/burio_16",
+		date: "2026/3/6",
+		event: "社内LT会",
+	},
 };
 
 export function getSlideConfig(slug: string): SlideConfig | undefined {


### PR DESCRIPTION
## Summary
This PR adds a new slide deck template for internal LT (Lightning Talk) presentations using MDX format. It provides a reusable template structure with pre-configured styling, metadata, and Open Graph image generation.

## Key Changes
- **New slide deck**: Added `/mdx-template` route with complete presentation setup
  - `page.tsx`: Main presentation page using Reveal.js
  - `layout.tsx`: Layout with metadata and viewport configuration
  - `slides.mdx`: MDX content with slide components and sample content
  - `opengraph-image.tsx`: Dynamic OG image generation (1200x630px)
  - `slides/cover.tsx`: Cover slide component
  - `slides/self-introduction.tsx`: Self-introduction slide component with custom styling

- **Homepage integration**: Added MDX template card to the main slides index (`/page.tsx`)

- **Configuration**: Added slide metadata to `SLIDES_CONFIG` in `lib/slides/config.ts`

## Notable Implementation Details
- Uses Next.js `ImageResponse` API for dynamic OG image generation with R2 CDN background images
- Leverages existing `RevealPresentation` component for consistent presentation framework
- MDX format allows mixing Markdown content with React components for flexible slide creation
- Includes self-introduction slide with custom layout and image support
- Configured with Japanese content as template example (easily customizable)
- Proper metadata setup for social media sharing (OpenGraph, Twitter cards, oEmbed)

https://claude.ai/code/session_01LF2AwcWy4qAd2KrFAZjyf9