### PR TITLE
Refactor slide components and update presentation assets

### DIFF
--- a/apps/web/src/app/oss-and-community-v2/slides.mdx
+++ b/apps/web/src/app/oss-and-community-v2/slides.mdx
@@ -1,6 +1,6 @@
 import {
-  PersonalHeadingSlide,
-  PersonalContentSlide,
+  HeadingSlide,
+  ContentSlide,
 } from "@/components/slides";
 import SelfIntroduction from "./slides/self-introduction";
 import Cover from "./slides/cover";
@@ -14,12 +14,12 @@ import Cover from "./slides/cover";
 
 </SelfIntroduction>
 
-<PersonalHeadingSlide>
+<HeadingSlide>
 
 みなさんReact Tokyo Fes<br />行きましたか？
 
-</PersonalHeadingSlide>
-<PersonalContentSlide title="もちろん行きました">
+</HeadingSlide>
+<ContentSlide title="もちろん行きました">
 
 <div className="r-stack">
   <img
@@ -38,9 +38,9 @@ import Cover from "./slides/cover";
   />
 </div>
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalContentSlide title="レポートも出てましたね">
+<ContentSlide title="レポートも出てましたね">
 
 - ぜひ読んでください！(書いた人ではありません)
 - [React Tokyoフェス2026イベントレポート](https://zenn.dev/react_tokyo/articles/2026-02-28-fest-report)
@@ -51,84 +51,84 @@ import Cover from "./slides/cover";
   style={{ margin: "0 auto", display: "block", maxHeight: "700px" }}
 />
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalHeadingSlide>
+<HeadingSlide>
 
 ただの参加者の感想
 
-</PersonalHeadingSlide>
+</HeadingSlide>
 
-<PersonalHeadingSlide>
+<HeadingSlide>
 
 めちゃくちゃ<br />~~タコスがうまかったです~~<br />学びも多く楽しかったです！
 
-</PersonalHeadingSlide>
+</HeadingSlide>
 
-<PersonalHeadingSlide>
+<HeadingSlide>
 
 終
 
-</PersonalHeadingSlide>
+</HeadingSlide>
 
 <Cover />
 
-<PersonalHeadingSlide>
+<HeadingSlide>
 
 今日はReact Tokyoフェスに参加したからできたことの話です
 
-</PersonalHeadingSlide>
+</HeadingSlide>
 
-<PersonalHeadingSlide>VitestにPRマージされました</PersonalHeadingSlide>
+<HeadingSlide>VitestにPRマージされました</HeadingSlide>
 
-<PersonalContentSlide title="Vitestとは？">
+<ContentSlide title="Vitestとは？">
 
 - JavaScriptの世界的なテストフレームワーク
 - あのvoidzeroが開発しているテストフレームワーク
 - GitHubスター数 16k+
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalHeadingSlide>
+<HeadingSlide>
 
 きっかけはPRのレビュー中
 
-</PersonalHeadingSlide>
+</HeadingSlide>
 
-<PersonalContentSlide title="バグ発見の経緯">
+<ContentSlide title="バグ発見の経緯">
 
 - Storybook用にインタラクションテストのconfigを作成
 - ファイル名: `vitest.storybook-browser.config.ts`（ハイフン入り）
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalContentSlide title="原因を突き止めた">
+<ContentSlide title="原因を突き止めた">
 
 - CLIでファイルを直接指定すると動く
 - Storybookから実行するとglobでconfigを検索 → 引っかからない
 - 原因: `resolveProjects.ts` の正規表現 `\w+` がハイフンを許容していなかった
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalContentSlide title="人生初のissue">
+<ContentSlide title="人生初のissue">
 
 - 恐る恐るissueを立ててみた
 - [vitest-dev/vitest #9739](https://github.com/vitest-dev/vitest/issues/9739)
 - 「とりあえず報告だけ...」くらいの温度感
 - この時はドキュメントを直そうぜの提案
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalContentSlide title="偶然の出会い">
+<ContentSlide title="偶然の出会い">
 
 - React Tokyoフェスでvoidzeroの人と話す機会が！
 - 「こんなissue立てたんですよ」と話してみた
 - 「初めてなんですが、どんなスタンスでいればいいですか？」と聞いた
 - **この会話はReact Tokyoフェスがなければ絶対に生まれなかった**
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalContentSlide title="PR提出 → マージ">
+<ContentSlide title="PR提出 → マージ">
 
 - 修正は `\w+` → `[\w-]+` のたった1文字
 - 2人のメンテナーにapproveされてマージ（2026/3/5）
@@ -140,9 +140,9 @@ import Cover from "./slides/cover";
   style={{ margin: "0 auto" }}
 />
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalContentSlide title="changelogにも名前が載った✌️">
+<ContentSlide title="changelogにも名前が載った✌️">
 
 <img
   src="/slides/oss-and-community/assets/changelog.png"
@@ -150,13 +150,13 @@ import Cover from "./slides/cover";
   style={{ margin: "0 auto", display: "block" }}
 />
 
-</PersonalContentSlide>
+</ContentSlide>
 
-<PersonalContentSlide title="感謝">
+<ContentSlide title="感謝">
 
 - React TokyoフェスのおかげでまさかのOSSコントリビュート！
   - [Hiroshi Ogawa](https://x.com/hiroshi_18181)さんありがとうございます
 - フロントエンドをやりたいけど知識不足な自分にも少し自信がついた
   - コミュニティに参加して良かった！イベントに参加して良かった！！
 
-</PersonalContentSlide>
+</ContentSlide>

--- a/apps/web/src/app/oss-and-community-v2/slides/cover.tsx
+++ b/apps/web/src/app/oss-and-community-v2/slides/cover.tsx
@@ -6,7 +6,7 @@ const config = getSlideConfig("oss-and-community-v2");
 export default function Cover() {
 	return (
 		<section
-			data-background-image={`${R2_BASE}/burioSlide/burio16Cover.png`}
+			data-background-image={`${R2_BASE}/外部登壇資料テンプレ/千_外部登壇スライド_表紙.png`}
 			data-background-size="contain"
 		>
 			<div className="text-left">

--- a/apps/web/src/app/oss-and-community-v2/slides/self-introduction.tsx
+++ b/apps/web/src/app/oss-and-community-v2/slides/self-introduction.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
-const BG_CONTENT = `${R2_BASE}/burioSlide/content.png`;
+const BG_CONTENT = `${R2_BASE}/外部登壇資料テンプレ/千_外部登壇スライド_本文.png`;
 
 interface SelfIntroductionProps {
 	children: ReactNode;
@@ -19,9 +19,9 @@ export default function SelfIntroduction({ children }: SelfIntroductionProps) {
 				/>
 
 				<div className="flex flex-col">
-					<h2 className="text-white">自己紹介</h2>
+					<h2 className="text-black">自己紹介</h2>
 
-					<div className="space-y-2 text-left text-white md:space-y-4 lg:space-y-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6 md:[&_ul]:space-y-4 lg:[&_ul]:space-y-6">
+					<div className="space-y-2 text-left text-black md:space-y-4 lg:space-y-6 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6 md:[&_ul]:space-y-4 lg:[&_ul]:space-y-6">
 						{children}
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
This PR refactors the slide component naming convention and updates presentation assets for the OSS and Community v2 presentation.

## Key Changes
- **Component Naming**: Renamed `PersonalHeadingSlide` to `HeadingSlide` and `PersonalContentSlide` to `ContentSlide` throughout the presentation for more generic, reusable naming
- **Background Assets**: Updated background image paths in cover and self-introduction slides to use new template assets:
  - Cover slide: `burioSlide/burio16Cover.png` → `外部登壇資料テンプレ/千_外部登壇スライド_表紙.png`
  - Self-introduction: `burioSlide/content.png` → `外部登壇資料テンプレ/千_外部登壇スライド_本文.png`
- **Text Color**: Updated self-introduction slide text color from white to black to match the new background template

## Implementation Details
- All 30+ instances of the old component names were updated to the new naming convention
- The component refactoring maintains the same functionality while improving naming clarity
- Text color adjustment ensures proper contrast with the updated background image

https://claude.ai/code/session_01Gv5g811pRP2WjwBsEMhPR3