### PR TITLE
feat(web): oss-and-community-v2スライドにVitestの実際のコード例を追加

### DIFF
--- a/apps/web/src/app/oss-and-community-v2/slides.mdx
+++ b/apps/web/src/app/oss-and-community-v2/slides.mdx
@@ -103,6 +103,7 @@ import Cover from "./slides/cover";
 
 - Storybookから実行するとglobでconfigを検索 → 引っかからない
 - `resolveProjects.ts` の正規表現がハイフンを許容していなかった
+- [実際のコード](https://github.com/vitest-dev/vitest/blob/main/packages/vitest/src/node/projects/resolveProjects.ts)
 
 <pre>
   <code

--- a/apps/web/src/app/oss-and-community-v2/slides.mdx
+++ b/apps/web/src/app/oss-and-community-v2/slides.mdx
@@ -1,7 +1,4 @@
-import {
-  HeadingSlide,
-  ContentSlide,
-} from "@/components/slides";
+import { HeadingSlide, ContentSlide } from "@/components/slides";
 import SelfIntroduction from "./slides/self-introduction";
 import Cover from "./slides/cover";
 
@@ -104,9 +101,46 @@ import Cover from "./slides/cover";
 
 <ContentSlide title="原因を突き止めた">
 
-- CLIでファイルを直接指定すると動く
 - Storybookから実行するとglobでconfigを検索 → 引っかからない
-- 原因: `resolveProjects.ts` の正規表現 `\w+` がハイフンを許容していなかった
+- `resolveProjects.ts` の正規表現がハイフンを許容していなかった
+
+<pre>
+  <code
+    className="language-typescript"
+    data-trim
+    data-noescape
+  >{`// packages/vitest/src/node/projects/resolveProjects.ts
+
+// vitest.config.*
+// vite.config.*
+// vitest.unit.config.*
+// vitest.unit-test.config.* ← これがマッチしない！
+
+const CONFIG_REGEXP = /^vite(?:st)?(?:\\.\\w+)?\\.config\\./
+//                                     ^^^^
+// \\w+ は [a-zA-Z0-9_] のみ → "-" にマッチしない 😱
+// vitest.storybook-browser.config.ts → マッチしない`}</code>
+</pre>
+
+</ContentSlide>
+
+<ContentSlide title="実際のglobの挙動">
+
+- CLIで直接指定 → そのまま使うのでOK ✅
+
+<pre>
+  <code
+    className="language-bash"
+    data-trim
+    data-noescape
+  >{`# CLI直接指定 → 問題なし
+$ vitest --config vitest.storybook-browser.config.ts
+
+# glob検索 → ハイフン入りファイル名がマッチしない
+vitest.storybook-browser.config.ts
+       ^^^^^^^^^^^^^^^^^^
+       \\w+ は [a-zA-Z0-9_] のみ → "-" にマッチしない`}</code>
+</pre>
 
 </ContentSlide>
 
@@ -130,15 +164,22 @@ import Cover from "./slides/cover";
 
 <ContentSlide title="PR提出 → マージ">
 
-- 修正は `\w+` → `[\w-]+` のたった1文字
+- 修正はたった1文字の変更
 - 2人のメンテナーにapproveされてマージ（2026/3/5）
 - PR: [vitest-dev/vitest #9760](https://github.com/vitest-dev/vitest/pull/9760)
 
-<img
-  src="/slides/oss-and-community/assets/vitest.png"
-  alt="vitest PR #9760"
-  style={{ margin: "0 auto" }}
-/>
+<pre>
+  <code
+    className="language-diff"
+    data-trim
+    data-noescape
+  >{`// packages/vitest/src/node/projects/resolveProjects.ts
+
+- const CONFIG_REGEXP = /^vite(?:st)?(?:\\.\\w+)?\\.config\\./
++ const CONFIG_REGEXP = /^vite(?:st)?(?:\\.[\\w-]+)?\\.config\\./
+//                                       ^^^
+//                                   ハイフンを追加！`}</code>
+</pre>
 
 </ContentSlide>
 
@@ -160,3 +201,9 @@ import Cover from "./slides/cover";
   - コミュニティに参加して良かった！イベントに参加して良かった！！
 
 </ContentSlide>
+
+<HeadingSlide>
+
+以上、Vitestコントリビューター(語弊)<br />ぶりおの自分語りLTでした。
+
+</HeadingSlide>


### PR DESCRIPTION
- 問題の原因となったCONFIG_REGEXPの実際のコードを表示するスライドを追加
- CLIとglob検索の挙動の違いを説明するスライドを追加
- PRのbefore/afterをdiff形式で表示するスライドに変更
- 締めのスライドを追加