### PR TITLE
fix(web): slides.mdxの閉じタグインデントによるビルドエラーを修正

### DIFF
--- a/apps/web/src/app/oss-and-community-v2/slides.mdx
+++ b/apps/web/src/app/oss-and-community-v2/slides.mdx
@@ -202,7 +202,8 @@ vitest.storybook-browser.config.ts
   - コミュニティに参加して良かった！イベントに参加して良かった！！
 - 今年もフェス楽しみにしてます！
   - 次はスタッフ側としてReact Tokyoに貢献する動きをしたいと思います！
-    </ContentSlide>
+
+</ContentSlide>
 
 <HeadingSlide>
 


### PR DESCRIPTION
</ContentSlide>がリストアイテム内にインデントされており、
MDXパーサーがリスト内の閉じタグとして解釈しビルドエラーになっていた。