### PR TITLE
feat(web): スライドページをRSC化してSSR対応

### DIFF
--- a/apps/web/src/app/25-graduate/page.tsx
+++ b/apps/web/src/app/25-graduate/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import RevealPresentation from "@/components/reveal-presentation";
 import Cover from "./slides/cover";
 import SlidesContent from "./slides.mdx";

--- a/apps/web/src/app/better-t-stack/page.tsx
+++ b/apps/web/src/app/better-t-stack/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import RevealPresentation from "@/components/reveal-presentation";
 import BackCover from "./slides/back-cover";
 import BusinessContent from "./slides/business-content";

--- a/apps/web/src/app/oss-and-community-v2/page.tsx
+++ b/apps/web/src/app/oss-and-community-v2/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import RevealPresentation from "@/components/reveal-presentation";
 import Cover from "./slides/cover";
 import SlidesContent from "./slides.mdx";

--- a/apps/web/src/app/oss-and-community/page.tsx
+++ b/apps/web/src/app/oss-and-community/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import RevealPresentation from "@/components/reveal-presentation";
 import Cover from "./slides/cover";
 import SlidesContent from "./slides.mdx";

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Route } from "next";
 import { SlideCard } from "@/components/slides";
 import { SLIDES_CONFIG } from "@/lib/slides/config";

--- a/apps/web/src/app/react-three-fiber/page.tsx
+++ b/apps/web/src/app/react-three-fiber/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import RevealPresentation from "@/components/reveal-presentation";
 import BackCover from "./slides/back-cover";
 import BusinessContent from "./slides/business-content";

--- a/apps/web/src/app/revealjs-slideDeck/page.tsx
+++ b/apps/web/src/app/revealjs-slideDeck/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import RevealPresentation from "@/components/reveal-presentation";
 import Content from "./slides/content";
 import Cover from "./slides/cover";

--- a/apps/web/src/app/tacotuesday/page.tsx
+++ b/apps/web/src/app/tacotuesday/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import RevealPresentation from "@/components/reveal-presentation";
 import Content from "../revealjs-slideDeck/slides/content";
 import RevealCover from "../revealjs-slideDeck/slides/cover";

--- a/apps/web/src/app/you-must-have-dotfiles/page.tsx
+++ b/apps/web/src/app/you-must-have-dotfiles/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import RevealPresentation from "@/components/reveal-presentation";
 import Cover from "./slides/cover";
 import SlidesContent from "./slides.mdx";

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,4 +1,3 @@
-"use client";
 import Link from "next/link";
 
 export default function Header() {


### PR DESCRIPTION
## Summary
- 全スライドページ・トップページ・Headerから`"use client"`を除去し、React Server Components化
- `RevealPresentation`のみClient Componentとして維持し、スライドコンテンツはサーバーでHTML生成
- Closes #173

## 変更内容
- `Header.tsx`から`"use client"`除去
- 全8スライドの`page.tsx`から`"use client"`除去
- トップページの`page.tsx`から`"use client"`除去

## 仕組み
- Server Component(page.tsx)でMDX・Cover・HeadingSlide等をHTMLに変換
- そのHTMLをchildrenとしてClient Component(RevealPresentation)に渡す
- ブラウザはHTMLを即表示、Reveal.jsが後から初期化するだけ
- MDXパーサーや静的コンポーネントのJSはクライアントに送られなくなる

## Test plan
- [ ] 各スライドページが正常に表示・ナビゲーションできること
- [ ] トップページのスライドカード一覧が正常に表示されること
- [ ] embedページが正常に動作すること
- [ ] ビルドが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)