### PR TITLE
refactor(web): スライド内の img を Next.js Image に置き換え

### DIFF
--- a/apps/web/src/app/25-graduate/slides/self-introduction.tsx
+++ b/apps/web/src/app/25-graduate/slides/self-introduction.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import type { ReactNode } from "react";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
@@ -13,9 +14,11 @@ export default function SelfIntroduction({ children }: SelfIntroductionProps) {
       data-background-size="contain"
     >
       <div className="flex h-full flex-row items-center justify-evenly">
-        <img
+        <Image
           src="/slides/react-three-fiber/assets/burio.png"
           alt="ぶりおの写真"
+          width={500}
+          height={500}
           className="r-stretch"
         />
 

--- a/apps/web/src/app/autofocus-correct-usage/slides.mdx
+++ b/apps/web/src/app/autofocus-correct-usage/slides.mdx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { PersonalHeadingSlide, PersonalContentSlide } from "@/components/slides";
 import SelfIntroduction from "./slides/self-introduction";
 import {
@@ -11,6 +12,7 @@ import {
 
 - ぶりお [@burio_16](https://x.com/burio_16)
 - タコスとTottenham Hotspur FCが大好き
+- 最近食品衛生責任者の資格講習を受けたので<br />みんなにタコスを振る舞うことができるようになりました🌮
 
 </SelfIntroduction>
 
@@ -56,9 +58,11 @@ autofocusってなーに？
 - **そこで初めてautofocusという属性の存在を知った**
 
 </div>
-<img
+<Image
   src="/slides/autofocus-correct-usage/assets/pr-532.png"
   alt="a11y周り修正 PR #532"
+  width={1820}
+  height={1316}
   className="max-w-[40%] h-auto rounded-lg"
 />
 </div>
@@ -89,9 +93,11 @@ autofocusってなーに？
   - フォーカスが突然移動し、現在位置を見失う
 
 </div>
-<img
+<Image
   src="/slides/autofocus-correct-usage/assets/oxlint-no-autofocus.png"
   alt="oxlint jsx-a11y/no-autofocus の警告出力"
+  width={1108}
+  height={211}
   className="max-w-[45%] h-auto rounded-lg"
 />
 </div>
@@ -237,9 +243,11 @@ HTML autofocusなしで、Linterにも怒られない
 <PersonalContentSlide title="【宣伝】Frontend Conference Nagoya 2026 前夜祭！">
 
 <div className="flex items-center gap-8">
-<img
+<Image
   src="/slides/autofocus-correct-usage/assets/fcn2026-eve.png"
   alt="Frontend Conference Nagoya 2026 前夜祭 - 2026.05.08(Fri) 19:00 株式会社スタメン 名古屋オフィス"
+  width={762}
+  height={443}
   className="max-w-[55%] h-auto rounded-lg"
 />
 <div>

--- a/apps/web/src/app/autofocus-correct-usage/slides/self-introduction.tsx
+++ b/apps/web/src/app/autofocus-correct-usage/slides/self-introduction.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import type { ReactNode } from "react";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
@@ -11,9 +12,11 @@ export default function SelfIntroduction({ children }: SelfIntroductionProps) {
   return (
     <section data-background-image={BG_CONTENT} data-background-size="contain">
       <div className="flex h-full flex-row items-center justify-evenly">
-        <img
+        <Image
           src="/slides/react-three-fiber/assets/burio.png"
           alt="ぶりおの写真"
+          width={500}
+          height={500}
           className="r-stretch"
         />
 

--- a/apps/web/src/app/better-t-stack/slides/content.tsx
+++ b/apps/web/src/app/better-t-stack/slides/content.tsx
@@ -73,7 +73,7 @@ export default function Content() {
         </div>
       </section>
       <section data-background-image={BG_CONTENT} data-background-size="contain">
-        <img src={betterTstackImg.src} alt="Better T-Stackのトップ画面" className="r-stretch" />
+        <Image src={betterTstackImg} alt="Better T-Stackのトップ画面" className="r-stretch" />
       </section>
       <section data-background-image={BG_CONTENT} data-background-size="contain">
         <div className="flex h-full flex-row items-center justify-center">
@@ -90,14 +90,14 @@ export default function Content() {
           </div>
 
           <div className="r-stack">
-            <img
-              src={webBuilderImg.src}
+            <Image
+              src={webBuilderImg}
               className="fragment fade-out"
               data-fragment-index="0"
               alt="Web Builder"
             />
-            <img
-              src={cliBuilderImg.src}
+            <Image
+              src={cliBuilderImg}
               className="fragment fade-in"
               data-fragment-index="0"
               alt="CLI Builder"
@@ -142,15 +142,15 @@ export default function Content() {
             <div className="text-left text-black">
               vercelのOSS支援プログラムに選ばれていました🔥
             </div>
-            <img src={vercelImg.src} alt="vercelの支援プログラム" className="r-stretch" />{" "}
+            <Image src={vercelImg} alt="vercelの支援プログラム" className="r-stretch" />{" "}
           </div>
         </section>
       </section>
       <section data-background-image={BG_CONTENT} data-background-size="contain">
         <div className="flex h-full flex-row items-center justify-center gap-8">
           <div className="w-[30%] text-left text-black">issue建ててみました。</div>
-          <img
-            src={issueImg.src}
+          <Image
+            src={issueImg}
             alt="ぶりおがissue建てている様子"
             className="r-stretch !max-w-[60%]"
           />
@@ -164,8 +164,8 @@ export default function Content() {
             <br />
             日本好きそうじゃね...?
           </div>
-          <img
-            src={amanProfileImg.src}
+          <Image
+            src={amanProfileImg}
             alt="アマンのプロフィール"
             className="r-stretch !max-w-[60%]"
           />
@@ -174,7 +174,7 @@ export default function Content() {
       <section data-background-image={BG_CONTENT} data-background-size="contain">
         <div className="flex h-full flex-row items-center justify-center gap-8">
           <div className="w-[30%] text-left text-black">Twitterで釣ろうとしてみました。</div>
-          <img src={burioTweetImg.src} alt="ぶりおのツイート" className="r-stretch !max-w-[60%]" />
+          <Image src={burioTweetImg} alt="ぶりおのツイート" className="r-stretch !max-w-[60%]" />
         </div>
       </section>
       <section data-background-image={BG_CONTENT} data-background-size="contain">
@@ -184,7 +184,7 @@ export default function Content() {
             <br />
             お願いしてみました。
           </div>
-          <img src={amanReplyImg.src} alt="アマンのリプライ" className="r-stretch !max-w-[60%]" />
+          <Image src={amanReplyImg} alt="アマンのリプライ" className="r-stretch !max-w-[60%]" />
         </div>
       </section>
       <section data-background-image={BG_CONTENT} data-background-size="contain">
@@ -194,7 +194,7 @@ export default function Content() {
             <br />
             無念。
           </div>
-          <img src={SorryImg.src} alt="ごめんなさい" className="r-stretch !max-w-[60%]" />
+          <Image src={SorryImg} alt="ごめんなさい" className="r-stretch !max-w-[60%]" />
         </div>
       </section>
       <section data-background-image={BG_HEADING} data-background-size="contain">

--- a/apps/web/src/app/better-t-stack/slides/self-introduction.tsx
+++ b/apps/web/src/app/better-t-stack/slides/self-introduction.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import burioImg from "./assets/burio.png";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
@@ -9,7 +10,7 @@ export default function SelfIntroduction() {
       data-background-size="contain"
     >
       <div className="flex h-full flex-row flex-row items-center justify-evenly">
-        <img src={burioImg.src} alt="ぶりおの写真" className="r-stretch" />
+        <Image src={burioImg} alt="ぶりおの写真" className="r-stretch" />
 
         <div className="flex flex-col">
           <h2 className="text-black">自己紹介</h2>

--- a/apps/web/src/app/oss-and-community-v2/slides.mdx
+++ b/apps/web/src/app/oss-and-community-v2/slides.mdx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { HeadingSlide, ContentSlide } from "@/components/slides";
 import SelfIntroduction from "./slides/self-introduction";
 import Cover from "./slides/cover";
@@ -19,18 +20,22 @@ import Cover from "./slides/cover";
 <ContentSlide title="もちろん行きました">
 
 <div className="r-stack">
-  <img
+  <Image
     className="fragment fade-out"
     data-fragment-index="0"
     src="/slides/oss-and-community-v2/assets/tacos.JPG"
     alt="React Tokyoフェス"
+    width={4032}
+    height={3024}
     style={{ margin: "0 auto", display: "block", maxHeight: "700px" }}
   />
-  <img
+  <Image
     className="fragment fade-in"
     data-fragment-index="0"
     src="/slides/oss-and-community-v2/assets/react-tokyo-fes.JPG"
     alt="タコス"
+    width={4032}
+    height={3024}
     style={{ margin: "0 auto", display: "block", maxHeight: "700px" }}
   />
 </div>
@@ -42,9 +47,11 @@ import Cover from "./slides/cover";
 - ぜひ読んでください！(書いた人ではありません)
 - [React Tokyoフェス2026イベントレポート](https://zenn.dev/react_tokyo/articles/2026-02-28-fest-report)
 
-<img
+<Image
   src="/slides/oss-and-community-v2/assets/reacttokyo-report.png"
   alt="React Tokyoフェス 2026 イベントレポート"
+  width={1200}
+  height={630}
   style={{ margin: "0 auto", display: "block", maxHeight: "700px" }}
 />
 
@@ -182,9 +189,11 @@ vitest.storybook-browser.config.ts
 
 <ContentSlide title="changelogにも名前が載った✌️">
 
-<img
+<Image
   src="/slides/oss-and-community/assets/changelog.png"
   alt="vitest changelog"
+  width={1760}
+  height={326}
   style={{ margin: "0 auto", display: "block" }}
 />
 

--- a/apps/web/src/app/oss-and-community-v2/slides/self-introduction.tsx
+++ b/apps/web/src/app/oss-and-community-v2/slides/self-introduction.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import type { ReactNode } from "react";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
@@ -11,9 +12,11 @@ export default function SelfIntroduction({ children }: SelfIntroductionProps) {
   return (
     <section data-background-image={BG_CONTENT} data-background-size="contain">
       <div className="flex h-full flex-row items-center justify-evenly">
-        <img
+        <Image
           src="/slides/react-three-fiber/assets/burio.png"
           alt="ぶりおの写真"
+          width={500}
+          height={500}
           className="r-stretch"
         />
 

--- a/apps/web/src/app/oss-and-community/slides.mdx
+++ b/apps/web/src/app/oss-and-community/slides.mdx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { PersonalHeadingSlide, PersonalContentSlide } from "@/components/slides";
 import SelfIntroduction from "./slides/self-introduction";
 
@@ -14,9 +15,11 @@ import SelfIntroduction from "./slides/self-introduction";
 - チキンティンガタコス
 - マンゴーとハラペーニョのサルサ
 
-<img
+<Image
   src="/slides/oss-and-community/assets/chikintinga.JPG"
   alt="チキンティンガ"
+  width={1474}
+  height={1110}
   style={{ margin: "0 auto", display: "block", maxHeight: "700px" }}
 />
 
@@ -77,9 +80,11 @@ import SelfIntroduction from "./slides/self-introduction";
 - 2人のメンテナーにapproveされてマージ（2026/3/5）
 - PR: [vitest-dev/vitest #9760](https://github.com/vitest-dev/vitest/pull/9760)
 
-<img
+<Image
   src="/slides/oss-and-community/assets/vitest.png"
   alt="vitest PR #9760"
+  width={1200}
+  height={600}
   style={{ margin: "0 auto" }}
 />
 
@@ -87,9 +92,11 @@ import SelfIntroduction from "./slides/self-introduction";
 
 <PersonalContentSlide title="changelogにも名前が載った✌️">
 
-<img
+<Image
   src="/slides/oss-and-community/assets/changelog.png"
   alt="vitest changelog"
+  width={1760}
+  height={326}
   style={{ margin: "0 auto", display: "block" }}
 />
 

--- a/apps/web/src/app/oss-and-community/slides/self-introduction.tsx
+++ b/apps/web/src/app/oss-and-community/slides/self-introduction.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import type { ReactNode } from "react";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
@@ -11,9 +12,11 @@ export default function SelfIntroduction({ children }: SelfIntroductionProps) {
   return (
     <section data-background-image={BG_CONTENT} data-background-size="contain">
       <div className="flex h-full flex-row items-center justify-evenly">
-        <img
+        <Image
           src="/slides/react-three-fiber/assets/burio.png"
           alt="ぶりおの写真"
+          width={500}
+          height={500}
           className="r-stretch"
         />
 

--- a/apps/web/src/app/react-three-fiber/slides/self-introduction.tsx
+++ b/apps/web/src/app/react-three-fiber/slides/self-introduction.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 
 export default function SelfIntroduction() {
@@ -7,9 +9,11 @@ export default function SelfIntroduction() {
       data-background-size="contain"
     >
       <div className="flex h-full flex-row flex-row items-center justify-evenly">
-        <img
+        <Image
           src="/slides/React-three-fiber/assets/burio.png"
           alt="ぶりおの写真"
+          width={500}
+          height={500}
           className="r-stretch"
         />
 

--- a/apps/web/src/app/revealjs-slideDeck/slides/content.tsx
+++ b/apps/web/src/app/revealjs-slideDeck/slides/content.tsx
@@ -76,7 +76,7 @@ export default function Content() {
               </li>
             </ul>
           </div>
-          <img src={revealImg.src} alt="reveal.js" className="w-[50%]" />
+          <Image src={revealImg} alt="reveal.js" className="w-[50%]" />
         </div>
       </section>
       <section data-background-image={BG_CONTENT} data-background-size="contain">
@@ -110,7 +110,7 @@ export default function Content() {
             </ul>
           </div>
           <div className="r-stack">
-            <img src={ogpImg.src} alt="ogp画像" />
+            <Image src={ogpImg} alt="ogp画像" />
           </div>
         </div>
       </section>
@@ -178,7 +178,7 @@ export default function Content() {
               <li>Tailwind競合して文字色が変わらなかった</li>
             </ul>
           </div>
-          <img src={pdfExportImg.src} alt="ogp画像" className="w-[50%]" />
+          <Image src={pdfExportImg} alt="ogp画像" className="w-[50%]" />
         </div>
       </section>
       <section data-background-image={BG_CONTENT} data-background-size="contain">

--- a/apps/web/src/app/you-must-have-dotfiles/slides.mdx
+++ b/apps/web/src/app/you-must-have-dotfiles/slides.mdx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import {
   HeadingSlide,
   ContentSlide,
@@ -33,9 +34,11 @@ Nixを使ってdotfilesをやりたい方は、[2026年にnixを始める方法]
 <ContentSlide>
   <div className="flex items-center gap-8">
     {"私は管理してます"}
-    <img
+    <Image
       src="/slides/you-must-have-dotfiles/assets/mydotfiles.png"
       alt="mydotfiles"
+      width={1850}
+      height={1138}
       className="max-w-[75%] h-auto"
     />
   </div>
@@ -51,7 +54,7 @@ Nixを使ってdotfilesをやりたい方は、[2026年にnixを始める方法]
 - 設定してる部分送ってくれや！<br />でもLINEだと送りにくいか😢
 
 </div>
-<img src="/slides/you-must-have-dotfiles/assets/LINE.png" alt="同期とのLINEのやりとり" className="max-w-[75%] h-auto" />
+<Image src="/slides/you-must-have-dotfiles/assets/LINE.png" alt="同期とのLINEのやりとり" width={768} height={348} className="max-w-[75%] h-auto" />
 </div>
 </ContentSlide>
 
@@ -97,7 +100,7 @@ dotfilesで管理できると便利じゃない？
 - GitHub上でスター数が17k以上ありdotfilesの管理ツールとして人気
 
 </div>
-<img src="/slides/you-must-have-dotfiles/assets/chezmoi.png" alt="chezmoiの画像" className="max-w-[50%]" />
+<Image src="/slides/you-must-have-dotfiles/assets/chezmoi.png" alt="chezmoiの画像" width={2510} height={1586} className="max-w-[50%]" />
 </div>
 </ContentSlide>
 

--- a/apps/web/src/app/you-must-have-dotfiles/slides/self-introduction.tsx
+++ b/apps/web/src/app/you-must-have-dotfiles/slides/self-introduction.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import type { ReactNode } from "react";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
@@ -13,9 +14,11 @@ export default function SelfIntroduction({ children }: SelfIntroductionProps) {
       data-background-size="contain"
     >
       <div className="flex h-full flex-row flex-row items-center justify-evenly">
-        <img
+        <Image
           src="/slides/react-three-fiber/assets/burio.png"
           alt="ぶりおの写真"
+          width={500}
+          height={500}
           className="r-stretch"
         />
 


### PR DESCRIPTION
## Summary
- 各スライドの `<img>` を `next/image` の `<Image>` に統一
- 静的インポート画像は import オブジェクト経由で width/height 自動付与、MDX の外部パス画像には明示的に width/height を指定
- autofocus スライドに食品衛生責任者の話題を追記

## Test plan
- [x] Playwright MCP で全スライドルートを巡回し、最終ページまで遷移できコンソールエラーが出ないことを確認
  - `/`, `/autofocus-correct-usage`, `/oss-and-community-v2`, `/oss-and-community`, `/25-graduate`, `/you-must-have-dotfiles`, `/revealjs-slideDeck`, `/tacotuesday`, `/better-t-stack`, `/react-three-fiber`
- [x] `/spurs` は空ディレクトリのため 404（従来通り、本PRの対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)