### PR TITLE
perf(web): HTML レスポンスに edge cache 用の Cache-Control ヘッダを追加

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -18,6 +18,16 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      {
+        // /api 配下は除外して全 HTML に edge cache を効かせる
+        source: "/((?!api/).*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=0, s-maxage=600, stale-while-revalidate=86400",
+          },
+        ],
+      },
     ];
   },
 };


### PR DESCRIPTION
Cloudflare edge で HTML を 10 分キャッシュ + SWR 1 日。デプロイ後の反映を 待ちつつ、再訪時の体感速度を上げるため。`/api/*` は対象外。