### PR TITLE
perf(web): HTML と /_next/image に edge cache を効かせる

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -7,6 +7,11 @@ const nextConfig: NextConfig = {
   // reactCompiler: true, // Disabled due to __name esbuild helper conflict with Cloudflare Workers
   devIndicators: process.env.NEXT_PUBLIC_HIDE_DEVTOOLS ? false : undefined,
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
+  images: {
+    // /_next/image の Cache-Control の max-age を制御する。
+    // headers() では上書きできないため、ここで明示する。
+    minimumCacheTTL: 3600,
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- HTML レスポンスに `Cache-Control: public, max-age=0, s-maxage=600, stale-while-revalidate=86400` を付与し、Cloudflare edge を 10 分新鮮 + SWR 1 日に
- `/_next/image` は `headers()` で上書きできないため `images.minimumCacheTTL: 3600` を追加し、ブラウザ・edge 両方で 1 時間キャッシュ
- `/api/*` は対象外

## Why
- 従来は HTML が `public, max-age=0, must-revalidate` 固定で、edge HIT はしていたものの体感速度や CDN 効率が最適でなかった
- `/_next/image` も同様に `max-age=0` のまま返り、ブラウザの再検証が毎回発生していた

## Test plan
- [ ] staging deploy 後 `curl -sI https://myslides-staging.koutarouhanabusa.workers.dev/autofocus-correct-usage | grep -i cache-control` で新ヘッダ確認
- [ ] `/_next/image?...` のレスポンスで `max-age=3600` を確認
- [ ] スライドを 1 枚編集 → デプロイ → 10 分以内に反映されることを確認
- [ ] `cf-cache-status: HIT` が継続して出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)