### PR TITLE
feat(web): スライドを複数イベントで併記できるようにする

### DIFF
--- a/apps/web/src/app/25-graduate/slides/cover.tsx
+++ b/apps/web/src/app/25-graduate/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const TEMPLATE_PATH = "外部登壇資料テンプレ";
@@ -11,7 +11,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3>{config.event}</h3>
+        <h3>{formatEvent(config.event)}</h3>
         <br />
         <h1 className="leading-tight">{config.title}</h1>
         <br />

--- a/apps/web/src/app/autofocus-correct-usage/slides/cover.tsx
+++ b/apps/web/src/app/autofocus-correct-usage/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const config = getSlideConfig("autofocus-correct-usage");
@@ -10,7 +10,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3>{config.event}</h3>
+        <h3>{formatEvent(config.event)}</h3>
         <br />
         <h1 className="leading-tight">
           autofocusの正しい用法を

--- a/apps/web/src/app/better-t-stack/slides/cover.tsx
+++ b/apps/web/src/app/better-t-stack/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const config = getSlideConfig("better-t-stack");
@@ -10,7 +10,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3>{config.event}</h3>
+        <h3>{formatEvent(config.event)}</h3>
         <br />
         <h1 className="leading-tight">
           より良い技術スタックで

--- a/apps/web/src/app/oss-and-community-v2/slides/cover.tsx
+++ b/apps/web/src/app/oss-and-community-v2/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const config = getSlideConfig("oss-and-community-v2");
@@ -10,7 +10,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3>{config.event}</h3>
+        <h3>{formatEvent(config.event)}</h3>
         <br />
         <h1 className="leading-tight">{config.title}</h1>
         <br />

--- a/apps/web/src/app/oss-and-community/slides/cover.tsx
+++ b/apps/web/src/app/oss-and-community/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const config = getSlideConfig("oss-and-community");
@@ -10,7 +10,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3>{config.event}</h3>
+        <h3>{formatEvent(config.event)}</h3>
         <br />
         <h1 className="leading-tight">{config.title}</h1>
         <br />

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -31,6 +31,7 @@ export default function Home() {
           title={autofocus.title}
           date={autofocus.date}
           event={autofocus.event}
+          url={autofocus.eventUrl}
         >
           <AutofocusCover />
         </SlideCard>

--- a/apps/web/src/app/react-three-fiber/slides/cover.tsx
+++ b/apps/web/src/app/react-three-fiber/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const config = getSlideConfig("react-three-fiber");
@@ -10,7 +10,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3>{config.event}</h3>
+        <h3>{formatEvent(config.event)}</h3>
         <br />
         <h1 className="leading-tight">
           WebGL入門

--- a/apps/web/src/app/revealjs-slideDeck/slides/cover.tsx
+++ b/apps/web/src/app/revealjs-slideDeck/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const config = getSlideConfig("revealjs-slideDeck");
@@ -10,7 +10,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3>{config.event}</h3>
+        <h3>{formatEvent(config.event)}</h3>
         <br />
         <h1 className="leading-tight">
           自分だけの

--- a/apps/web/src/app/tacotuesday/slides/cover.tsx
+++ b/apps/web/src/app/tacotuesday/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const config = getSlideConfig("tacotuesday");
@@ -10,7 +10,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3 className="!text-white">{config.event}</h3>
+        <h3 className="!text-white">{formatEvent(config.event)}</h3>
         <h1 className="!text-white leading-tight">{config.title}</h1>
         <br />
         <h3 className="!text-white">{config.author} @burio_16</h3>

--- a/apps/web/src/app/you-must-have-dotfiles/slides/cover.tsx
+++ b/apps/web/src/app/you-must-have-dotfiles/slides/cover.tsx
@@ -1,4 +1,4 @@
-import { getSlideConfig } from "@/lib/slides/config";
+import { formatEvent, getSlideConfig } from "@/lib/slides/config";
 
 const R2_BASE = process.env.NEXT_PUBLIC_R2_BASE_URL;
 const TEMPLATE_PATH = "外部登壇資料テンプレ";
@@ -11,7 +11,7 @@ export default function Cover() {
       data-background-size="contain"
     >
       <div className="text-left">
-        <h3>{config.event}</h3>
+        <h3>{formatEvent(config.event)}</h3>
         <br />
         <h1 className="leading-tight">
           Vim使いでなくても

--- a/apps/web/src/components/slides/SlideCard.tsx
+++ b/apps/web/src/components/slides/SlideCard.tsx
@@ -2,21 +2,32 @@
 
 import type { Route } from "next";
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import RevealPresentation from "@/components/reveal-presentation";
 
 interface SlideCardProps {
   href: Route;
   title: string;
   date: string;
-  event?: string;
-  url?: string;
+  event?: string | string[];
+  url?: string | string[];
   children: React.ReactNode;
+}
+
+function toEventEntries(
+  event: string | string[] | undefined,
+  url: string | string[] | undefined,
+): Array<{ name: string; url?: string }> {
+  if (!event) return [];
+  const names = Array.isArray(event) ? event : [event];
+  const urls = Array.isArray(url) ? url : url ? [url] : [];
+  return names.filter((name) => name).map((name, i) => ({ name, url: urls[i] || undefined }));
 }
 
 export default function SlideCard({ href, title, date, event, url, children }: SlideCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
+  const eventEntries = toEventEntries(event, url);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -62,23 +73,27 @@ export default function SlideCard({ href, title, date, event, url, children }: S
       </Link>
       <div className="bg-white p-3 md:p-4">
         <h3 className="m-0 text-gray-700 text-lg md:text-xl lg:text-3xl">{title}</h3>
-        {(date || event) && (
+        {(date || eventEntries.length > 0) && (
           <div className="mt-1 flex flex-wrap items-center gap-1 text-gray-500 text-xs md:mt-2 md:gap-2 md:text-sm lg:text-base">
             {date && <span>{date}</span>}
-            {date && event && <span className="text-gray-300">|</span>}
-            {event &&
-              (url ? (
-                <a
-                  href={url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 text-xs no-underline md:text-sm lg:text-base"
-                >
-                  {event}
-                </a>
-              ) : (
-                <span className="text-xs md:text-sm lg:text-base">{event}</span>
-              ))}
+            {date && eventEntries.length > 0 && <span className="text-gray-300">|</span>}
+            {eventEntries.map((entry, i) => (
+              <Fragment key={`${entry.name}-${i}`}>
+                {i > 0 && <span className="text-gray-300">/</span>}
+                {entry.url ? (
+                  <a
+                    href={entry.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 text-xs no-underline md:text-sm lg:text-base"
+                  >
+                    {entry.name}
+                  </a>
+                ) : (
+                  <span className="text-xs md:text-sm lg:text-base">{entry.name}</span>
+                )}
+              </Fragment>
+            ))}
           </div>
         )}
       </div>

--- a/apps/web/src/lib/slides/config.ts
+++ b/apps/web/src/lib/slides/config.ts
@@ -7,8 +7,13 @@ export interface SlideConfig {
   author: string;
   authorUrl: string;
   date: string;
-  event?: string;
-  eventUrl?: string;
+  event?: string | string[];
+  eventUrl?: string | string[];
+}
+
+export function formatEvent(event: string | string[] | undefined): string {
+  if (!event) return "";
+  return Array.isArray(event) ? event.join(" / ") : event;
 }
 
 export const SLIDES_CONFIG: Record<string, SlideConfig> = {
@@ -100,7 +105,8 @@ export const SLIDES_CONFIG: Record<string, SlideConfig> = {
     author: "ぶりお",
     authorUrl: "https://twitter.com/burio_16",
     date: "2026/4/20",
-    event: "社内LT会",
+    event: ["社内LT会", "Frontend Conference Nagoya 2026 前夜祭！"],
+    eventUrl: ["", "https://stmn.connpass.com/event/390165/"],
   },
 };
 
@@ -126,12 +132,13 @@ export function createSlideMetadata(slug: string): Metadata {
   const config = getSlideConfig(slug);
   const slideUrl = `${BASE_URL}/${slug}`;
   const handle = getAuthorHandle(config.authorUrl);
-  const ogDescription = config.event
-    ? `${config.event} での発表資料 by ${config.author} @${handle}`
+  const eventLabel = formatEvent(config.event);
+  const ogDescription = eventLabel
+    ? `${eventLabel} での発表資料 by ${config.author} @${handle}`
     : config.description;
 
   return {
-    title: config.event ? `${config.title} | ${config.event}` : `${config.title} | mySlides`,
+    title: eventLabel ? `${config.title} | ${eventLabel}` : `${config.title} | mySlides`,
     description: config.description,
     openGraph: {
       title: config.title,
@@ -164,7 +171,7 @@ export function createOgpProps(slug: string): OgpProps {
   return {
     alt: config.title,
     title: config.title,
-    event: config.event ?? "",
+    event: formatEvent(config.event),
     author: `${config.author} @${handle}`,
   };
 }


### PR DESCRIPTION
## Summary

- 1 つのスライドを複数イベントで発表する場合に、イベント名を ` / ` 区切りで併記できるように `SlideConfig.event` / `eventUrl` を `string | string[]` に拡張
- `autofocus-correct-usage` を「社内LT会」「Frontend Conference Nagoya 2026 前夜祭！」の併記に更新（後者だけ connpass URL を持つ）

## 変更点

### `apps/web/src/lib/slides/config.ts`
- `SlideConfig.event?: string` → `string | string[]`
- `SlideConfig.eventUrl?: string` → `string | string[]`
- `formatEvent(event)` ヘルパーを追加（配列なら ` / ` で join）し、`createSlideMetadata` / `createOgpProps` から呼び出し

### `apps/web/src/components/slides/SlideCard.tsx`
- props を `string | string[]` 対応に
- `toEventEntries(event, url)` で配列を `Array<{ name, url? }>` に正規化
- `index` ごとに URL の有無で `<a>` or `<span>` を切り替え。URL が空文字 / undefined のイベントはリンクなしで描画

例: `event=["社内LT会", "Frontend Conference Nagoya 2026 前夜祭！"]`, `eventUrl=["", "https://stmn..."]` の場合
- 「社内LT会」 → プレーンテキスト
- 「Frontend Conference Nagoya 2026 前夜祭！」 → 連打可能なリンク

### `apps/web/src/app/page.tsx`
- `autofocus` の SlideCard に `url={autofocus.eventUrl}` を追加（複数イベントの URL を渡す）

### 各 `slides/cover.tsx` (9 ファイル)
- スライド表紙の `<h3>{config.event}</h3>` を `<h3>{formatEvent(config.event)}</h3>` に置換し、配列でも文字列として表示

## Test plan

- [x] `bunx tsc --noEmit` (apps/web): 0 errors（私が触ったファイルに関するエラーなし）
- [x] `bun run check` (oxlint + oxfmt): 0 errors（warnings は既存の `<img>` 由来でスコープ外）
- [x] commit 時の lefthook (`oxlint && oxfmt --write`): pass
- [ ] dev での目視確認: メイン環境（別 worktree）で実装した同等コードで確認済み:
  - `localhost:3001/` の autofocus カードに「社内LT会 / Frontend Conference Nagoya 2026 前夜祭！」が併記
  - 「Frontend Conference Nagoya 2026 前夜祭！」だけ青リンク、「社内LT会」はプレーンテキスト

## 関連
PR #192 (OGP フォント) は #193 で revert 済み。本 PR はフォント問題と独立した変更で、Workers 互換のフォント対応が別 PR (`fix/ogp-fonts-workers-compat`) で進行中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)