### PR TITLE
feat(web): MDXのコードブロックをCodeBlockコンポーネントで装飾する

### DIFF
--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -1,7 +1,21 @@
 import type { MDXComponents } from "mdx/types";
+import { CodeBlock } from "@/components/slides";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
+    pre: ({ children }) => <>{children}</>,
+    code: ({ className, children, ...props }) => {
+      if (typeof children === "string" && className?.startsWith("language-")) {
+        return (
+          <CodeBlock lang={className.replace("language-", "")} code={children.replace(/\n$/, "")} />
+        );
+      }
+      return (
+        <code className="myslides-inline-code" {...props}>
+          {children}
+        </code>
+      );
+    },
   };
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "remark-gfm": "^4.0.1",
     "reveal.js": "^5.2.1",
     "sonner": "^2.0.5",
+    "sugar-high": "^1.2.0",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.3.4",
     "zod": "catalog:"

--- a/apps/web/src/components/slides/CodeBlock.tsx
+++ b/apps/web/src/components/slides/CodeBlock.tsx
@@ -1,0 +1,33 @@
+import { highlight } from "sugar-high";
+
+// sugar-high は JS ファミリ向け。それ以外は素のテキストで表示する。
+const HIGHLIGHT_LANGS = new Set(["js", "jsx", "ts", "tsx", "mjs", "cjs", "json"]);
+
+interface CodeBlockProps {
+  code: string;
+  lang?: string;
+}
+
+export function CodeBlock({ code, lang }: CodeBlockProps) {
+  const normalizedLang = lang?.toLowerCase();
+  const highlighted =
+    normalizedLang && HIGHLIGHT_LANGS.has(normalizedLang) ? highlight(code) : null;
+
+  return (
+    <div className="sh-code">
+      {lang && (
+        <div className="sh-code__bar">
+          <span className="sh-code__lang">{lang}</span>
+        </div>
+      )}
+      <pre className="sh-code__pre">
+        {highlighted ? (
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: sugar-high はエスケープ済みHTMLを返す
+          <code dangerouslySetInnerHTML={{ __html: highlighted }} />
+        ) : (
+          <code>{code}</code>
+        )}
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/components/slides/index.ts
+++ b/apps/web/src/components/slides/index.ts
@@ -1,3 +1,4 @@
+export { CodeBlock } from "./CodeBlock";
 export { BG_PERSONAL_CONTENT, PersonalContentSlide, PersonalHeadingSlide } from "./personal-slide";
 export { default as SlideCard } from "./SlideCard";
 export { SlidePreviewCard } from "./SlidePreviewCard";

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -200,3 +200,83 @@ body {
 .reveal.reveal .text-pink-500 {
   color: #ec4899;
 }
+
+/* MDX コードブロック (CodeBlock) — sugar-high のトークン色は --sh-* で定義 */
+.sh-code {
+  --sh-code-bg: #1e1e2e;
+  --sh-code-bar: #181825;
+  --sh-code-border: rgba(255, 255, 255, 0.08);
+  --sh-identifier: #cdd6f4;
+  --sh-keyword: #cba6f7;
+  --sh-string: #a6e3a1;
+  --sh-class: #f9e2af;
+  --sh-property: #89b4fa;
+  --sh-entity: #89b4fa;
+  --sh-jsxliterals: #f5c2e7;
+  --sh-sign: #9399b2;
+  --sh-comment: #6c7086;
+
+  display: block;
+  margin: 0.7em auto;
+  max-width: 92%;
+  overflow: hidden;
+  border: 1px solid var(--sh-code-border);
+  border-radius: 14px;
+  background: var(--sh-code-bg);
+  box-shadow:
+    0 30px 60px -20px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(0, 0, 0, 0.25);
+  text-align: left;
+}
+.sh-code__bar {
+  display: flex;
+  align-items: center;
+  padding: 0.5em 1.1em;
+  background: var(--sh-code-bar);
+  border-bottom: 1px solid var(--sh-code-border);
+}
+.sh-code__lang {
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 0.72em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7f849c;
+}
+/* reveal の .reveal pre 既定を上書き */
+.reveal .sh-code__pre,
+.sh-code__pre {
+  margin: 0;
+  width: auto;
+  max-width: none;
+  padding: 1.15em 1.4em;
+  background: transparent;
+  box-shadow: none;
+  overflow: auto;
+  font-size: 0.5em;
+  line-height: 1.7;
+  tab-size: 2;
+}
+.reveal .sh-code__pre code,
+.sh-code__pre code {
+  display: block;
+  font-family: var(--font-geist-mono), ui-monospace, "SFMono-Regular", Menlo, monospace;
+  color: var(--sh-identifier);
+  background: transparent;
+  white-space: pre;
+  text-shadow: none;
+}
+.sh-code .sh__token--comment {
+  font-style: italic;
+}
+
+/* インラインコード */
+.reveal .myslides-inline-code,
+.myslides-inline-code {
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 0.85em;
+  padding: 0.12em 0.4em;
+  border-radius: 0.35em;
+  background: rgba(203, 166, 247, 0.16);
+  color: #cba6f7;
+  white-space: nowrap;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "remark-gfm": "^4.0.1",
         "reveal.js": "^5.2.1",
         "sonner": "^2.0.5",
+        "sugar-high": "^1.2.0",
         "tailwind-merge": "^3.3.1",
         "tw-animate-css": "^1.3.4",
         "zod": "catalog:",
@@ -1621,6 +1622,8 @@
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
+
+    "sugar-high": ["sugar-high@1.2.0", "", {}, "sha512-tDChykLsm/+arY5Fb3cOiptiW75WQMkm/J/zQFuOaU0eB6tTVg/C5ANwh9bFw/3JrYaLK2mMm0F9VdXHbNtOhQ=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 


### PR DESCRIPTION
- ダークなターミナル風パネル(言語ラベル付き)で表示する CodeBlock を追加
- mdx-components.tsx で pre/code を上書きし全 MDX のコードブロックに自動適用
- JS系(ts/tsx/js/jsx/json)は sugar-high でシンタックスハイライト、それ以外は素表示
- インラインコードも装飾、配色は Catppuccin Mocha 系