### PR TITLE
feat(web): reveal-presentation を公式 @revealjs/react ラッパーへ移行

### DIFF
--- a/.playwright-mcp/page-2026-06-23T14-00-56-795Z.yml
+++ b/.playwright-mcp/page-2026-06-23T14-00-56-795Z.yml
@@ -1,0 +1,4 @@
+- generic [active] [ref=e1]:
+    - region "Notifications alt+T"
+    - button "Open Next.js Dev Tools" [ref=e11] [cursor=pointer]:
+        - img [ref=e12]

--- a/.playwright-mcp/page-2026-06-23T14-01-13-033Z.yml
+++ b/.playwright-mcp/page-2026-06-23T14-01-13-033Z.yml
@@ -1,0 +1,154 @@
+- generic [active] [ref=e1]:
+    - generic [ref=e3]:
+        - heading "Burio's slide deck" [level=1] [ref=e4]
+        - generic [ref=e5]:
+            - generic [ref=e6]:
+                - link [ref=e7] [cursor=pointer]:
+                    - /url: /vite-plus-retro
+                    - application [ref=e9]:
+                        - generic [ref=e11]:
+                            - heading "TSKaigi 2026事後勉強会" [level=3] [ref=e12]
+                            - heading "Vite+を爆速で社内デザインシステムに導入してみた" [level=1] [ref=e13]
+                            - heading "ぶりお @burio_16" [level=3] [ref=e14]
+                        - text: Speaker notes
+                        - generic [ref=e18]: TSKaigi 2026事後勉強会 Vite+を爆速で社内デザインシステムに導入してみた ぶりお @burio_16
+                - generic [ref=e19]:
+                    - heading "Vite+を爆速で社内デザインシステムに導入してみた" [level=3] [ref=e20]
+                    - generic [ref=e21]:
+                        - generic [ref=e22]: 2026/06/25
+                        - generic [ref=e23]: "|"
+                        - link "TSKaigi 2026事後勉強会" [ref=e24] [cursor=pointer]:
+                            - /url: https://smarthr.connpass.com/event/392342/
+            - generic [ref=e25]:
+                - link [ref=e26] [cursor=pointer]:
+                    - /url: /tanstack-router-dir-structure
+                    - application [ref=e28]:
+                        - generic [ref=e30]:
+                            - heading "TSKaigi2026〜アフターパーティー〜" [level=3] [ref=e31]
+                            - heading "ぼくの考えた最強の TanStack Router ディレクトリ構成" [level=1] [ref=e32]:
+                                - text: ぼくの考えた最強の
+                                - text: TanStack Router ディレクトリ構成
+                            - heading "ぶりお @burio_16" [level=3] [ref=e33]
+                        - text: Speaker notes
+                        - generic [ref=e37]: TSKaigi2026〜アフターパーティー〜 ぼくの考えた最強の TanStack Router ディレクトリ構成 ぶりお @burio_16
+                - generic [ref=e38]:
+                    - heading "ぼくの考えた最強の TanStack Router ディレクトリ構成" [level=3] [ref=e39]
+                    - generic [ref=e40]:
+                        - generic [ref=e41]: 2026/06/12
+                        - generic [ref=e42]: "|"
+                        - link "TSKaigi2026〜アフターパーティー〜" [ref=e43] [cursor=pointer]:
+                            - /url: https://every.connpass.com/event/393937/
+            - generic [ref=e44]:
+                - link [ref=e45] [cursor=pointer]:
+                    - /url: /autofocus-correct-usage
+                    - application [ref=e47]:
+                        - generic [ref=e49]:
+                            - heading "社内LT会 / Frontend Conference Nagoya 2026 前夜祭！" [level=3] [ref=e50]
+                            - heading "autofocusの正しい用法を 知っていますか？" [level=1] [ref=e51]:
+                                - text: autofocusの正しい用法を
+                                - text: 知っていますか？
+                            - heading "ぶりお @burio_16" [level=3] [ref=e52]
+                        - text: Speaker notes
+                        - generic [ref=e56]: 社内LT会 / Frontend Conference Nagoya 2026 前夜祭！ autofocusの正しい用法を 知っていますか？ ぶりお @burio_16
+                - generic [ref=e57]:
+                    - heading "autofocusの正しい用法を知っていますか？" [level=3] [ref=e58]
+                    - generic [ref=e59]:
+                        - generic [ref=e60]: 2026/4/20
+                        - generic [ref=e61]: "|"
+                        - generic [ref=e62]: 社内LT会
+                        - generic [ref=e63]: /
+                        - link "Frontend Conference Nagoya 2026 前夜祭！" [ref=e64] [cursor=pointer]:
+                            - /url: https://stmn.connpass.com/event/390165/
+            - generic [ref=e65]:
+                - link "Loading..." [ref=e66] [cursor=pointer]:
+                    - /url: /oss-and-community-v2
+                    - generic [ref=e68]: Loading...
+                - generic [ref=e69]:
+                    - heading "実績解除：OSSコントリビュート V2" [level=3] [ref=e70]
+                    - generic [ref=e71]:
+                        - generic [ref=e72]: 2026/4/17
+                        - generic [ref=e73]: "|"
+                        - 'link "React Tokyo ミートアップ #15" [ref=e74] [cursor=pointer]':
+                            - /url: https://react-tokyo.connpass.com/event/386779/
+            - generic [ref=e75]:
+                - link "Loading..." [ref=e76] [cursor=pointer]:
+                    - /url: /oss-and-community
+                    - generic [ref=e78]: Loading...
+                - generic [ref=e79]:
+                    - heading "実績解除：OSSコントリビュート" [level=3] [ref=e80]
+                    - generic [ref=e81]:
+                        - generic [ref=e82]: 2026/3/23
+                        - generic [ref=e83]: "|"
+                        - generic [ref=e84]: 社内LT会
+            - generic [ref=e85]:
+                - link "Loading..." [ref=e86] [cursor=pointer]:
+                    - /url: /25-graduate
+                    - generic [ref=e88]: Loading...
+                - generic [ref=e89]:
+                    - heading "アウトプット、怖くないですか？" [level=3] [ref=e90]
+                    - generic [ref=e91]:
+                        - generic [ref=e92]: 2026/3/6
+                        - generic [ref=e93]: "|"
+                        - link "【25卒】新卒のつまずきを糧にしNight" [ref=e94] [cursor=pointer]:
+                            - /url: https://25-graduate.connpass.com/event/382072/
+            - generic [ref=e95]:
+                - link "Loading..." [ref=e96] [cursor=pointer]:
+                    - /url: /you-must-have-dotfiles
+                    - generic [ref=e98]: Loading...
+                - generic [ref=e99]:
+                    - heading "Vim使いでなくてもdotfilesを管理しよう" [level=3] [ref=e100]
+                    - generic [ref=e101]:
+                        - generic [ref=e102]: 2026/1/25
+                        - generic [ref=e103]: "|"
+                        - link "Yoriai.cafe 二日間限定オープン！" [ref=e104] [cursor=pointer]:
+                            - /url: https://peatix.com/event/4736534
+            - generic [ref=e105]:
+                - link "Loading..." [ref=e106] [cursor=pointer]:
+                    - /url: /revealjs-slideDeck
+                    - generic [ref=e108]: Loading...
+                - generic [ref=e109]:
+                    - heading "自分だけのスライドデッキを作ってみた" [level=3] [ref=e110]
+                    - generic [ref=e111]:
+                        - generic [ref=e112]: 2025/12/15
+                        - generic [ref=e113]: "|"
+                        - generic [ref=e114]: 社内LT会
+            - generic [ref=e115]:
+                - link "Loading..." [ref=e116] [cursor=pointer]:
+                    - /url: /tacotuesday
+                    - generic [ref=e118]: Loading...
+                - generic [ref=e119]:
+                    - heading "全人類タコスを食え" [level=3] [ref=e120]
+                    - generic [ref=e121]:
+                        - generic [ref=e122]: 2025/12/15
+                        - generic [ref=e123]: "|"
+                        - generic [ref=e124]: 社内LT会
+            - generic [ref=e125]:
+                - link "Loading..." [ref=e126] [cursor=pointer]:
+                    - /url: /better-t-stack
+                    - generic [ref=e128]: Loading...
+                - generic [ref=e129]:
+                    - heading "より良い技術スタックでcloudflareにデプロイしよう" [level=3] [ref=e130]
+                    - generic [ref=e131]:
+                        - generic [ref=e132]: 2025/12/10
+                        - generic [ref=e133]: "|"
+                        - link "Cloudflare Meet-up Tokyo Vol.9" [ref=e134] [cursor=pointer]:
+                            - /url: https://cfm-cts.connpass.com/event/374413/
+            - generic [ref=e135]:
+                - link "Loading..." [ref=e136] [cursor=pointer]:
+                    - /url: /react-three-fiber
+                    - generic [ref=e138]: Loading...
+                - generic [ref=e139]:
+                    - heading "WebGL入門 - Three.jsで良さげなプロフィールサイト作ってみた" [level=3] [ref=e140]
+                    - generic [ref=e141]:
+                        - generic [ref=e142]: 2025/11/14
+                        - generic [ref=e143]: "|"
+                        - link "React Tokyo ミートアップ#11" [ref=e144] [cursor=pointer]:
+                            - /url: https://react-tokyo.connpass.com/event/372887/
+    - generic [ref=e145]:
+        - img [ref=e147]
+        - button "Open Tanstack query devtools" [ref=e195] [cursor=pointer]:
+            - img [ref=e196]
+    - region "Notifications alt+T"
+    - button "Open Next.js Dev Tools" [ref=e249] [cursor=pointer]:
+        - img [ref=e250]
+    - alert [ref=e253]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@mySlides/api": "workspace:*",
     "@next/mdx": "^16.1.1",
     "@opennextjs/cloudflare": "^1.6.5",
+    "@revealjs/react": "^0.2.1",
     "@tanstack/react-form": "^1.12.3",
     "@tanstack/react-query": "^5.85.5",
     "@trpc/client": "catalog:",

--- a/apps/web/src/components/reveal-presentation.tsx
+++ b/apps/web/src/components/reveal-presentation.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Deck } from "@revealjs/react";
+import Markdown from "reveal.js/plugin/markdown/markdown";
+import { type ComponentProps, useEffect, useState } from "react";
 
 // reveal.jsのCSSはlayout.tsxで一括読み込み済み
+
+// reveal.js のバージョン差で型 export が揺れるため、Deck の prop 型から導出する
+type DeckConfig = NonNullable<ComponentProps<typeof Deck>["config"]>;
+type DeckPlugins = NonNullable<ComponentProps<typeof Deck>["plugins"]>;
+
+const plugins: DeckPlugins = [Markdown as unknown as DeckPlugins[number]];
 
 interface RevealPresentationProps {
   children?: React.ReactNode;
@@ -28,93 +36,60 @@ export default function RevealPresentation({
   embedded = false,
   config = {},
 }: RevealPresentationProps) {
-  const deckDivRef = useRef<HTMLDivElement>(null);
-  const deckRef = useRef<unknown>(null);
-  const [_isReady, setIsReady] = useState(false);
+  // reveal.js はクライアントで DOM を書き換えるため、SSR では Deck を描画せず
+  // マウント後にのみ描画して hydration mismatch を防ぐ
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    if (deckRef.current) return;
-    if (!deckDivRef.current) return;
+    setMounted(true);
+  }, []);
 
-    // Dynamic import to avoid esbuild __name issue
-    void Promise.all([import("reveal.js"), import("reveal.js/plugin/markdown/markdown")]).then(
-      ([RevealModule, MarkdownModule]) => {
-        const Reveal = RevealModule.default;
-        const Markdown = MarkdownModule.default;
+  if (!mounted) {
+    return <div className="reveal relative h-full w-full overflow-hidden" />;
+  }
 
-        if (!deckDivRef.current) return;
-
-        const deck = new Reveal(deckDivRef.current, {
-          transition,
-          // URLにスライド番号を反映（#/0, #/1 など）
-          hash: true,
-          // 16:9アスペクト比を維持しつつレスポンシブ対応
-          width: 1920,
-          height: 1080,
-          margin: 0.04,
-          minScale: 0.1,
-          maxScale: 2.0,
-          center: true,
-          embedded,
-          // 通常のスライドビューを使用（スワイプナビゲーション有効）
-          // 'scroll'にするとスクロールビューになりスワイプが効かない
-          view: null,
-          // モバイル幅でのスクロールビュー自動切り替えを無効化
-          // これがないとビューポートが狭いときに自動でスクロールビューになる
-          scrollActivationWidth: 0,
-          // embeddedモード時はフォーカス時のみキーボード操作を有効に
-          keyboardCondition: embedded ? "focused" : null,
-          // embeddedモード時はコントロールを非表示
-          controls: !embedded,
-          progress: !embedded,
-
-          // モバイル最適化設定
-          touch: true, // タッチナビゲーションを明示的に有効化
-
-          // パフォーマンス最適化
-          viewDistance: embedded ? 1 : 3, // プリロードするスライド数
-          mobileViewDistance: embedded ? 1 : 2, // モバイル向けのプリロード数
-
-          // ナビゲーション設定
-          navigationMode: "default", // 縦スライドを有効にするためdefaultに設定
-          disableLayout: false, // レイアウト計算を有効化してプレビューでも正しくスケーリング
-
-          // Markdownプラグインを追加
-          plugins: [Markdown],
-
-          ...config,
-        });
-
-        void deck.initialize().then(() => {
-          setIsReady(true);
-        });
-
-        deckRef.current = deck;
-      },
-    );
-
-    return () => {
-      try {
-        if (deckRef.current) {
-          (deckRef.current as { destroy: () => void }).destroy();
-          deckRef.current = null;
-        }
-      } catch {
-        console.warn("Reveal.js destroy call failed.");
-      }
-    };
-  }, [transition, embedded, config]);
+  const deckConfig: DeckConfig = {
+    transition,
+    // URLにスライド番号を反映（#/0, #/1 など）
+    hash: true,
+    // 16:9アスペクト比を維持しつつレスポンシブ対応
+    width: 1920,
+    height: 1080,
+    margin: 0.04,
+    minScale: 0.1,
+    maxScale: 2.0,
+    center: true,
+    embedded,
+    // 通常のスライドビューを使用（スワイプナビゲーション有効）
+    // 'scroll'にするとスクロールビューになりスワイプが効かない
+    view: null,
+    // モバイル幅でのスクロールビュー自動切り替えを無効化
+    scrollActivationWidth: 0,
+    // embeddedモード時はフォーカス時のみキーボード操作を有効に
+    keyboardCondition: embedded ? "focused" : null,
+    // embeddedモード時はコントロールを非表示
+    controls: !embedded,
+    progress: !embedded,
+    // タッチナビゲーションを明示的に有効化
+    touch: true,
+    // プリロードするスライド数
+    viewDistance: embedded ? 1 : 3,
+    mobileViewDistance: embedded ? 1 : 2,
+    // 縦スライドを有効にするためdefaultに設定
+    navigationMode: "default",
+    // レイアウト計算を有効化してプレビューでも正しくスケーリング
+    disableLayout: false,
+    ...config,
+  };
 
   return (
-    <div className="reveal relative h-full w-full overflow-hidden" ref={deckDivRef}>
-      <div className="slides">
-        {children || (
-          <>
-            <section>Slide 1</section>
-            <section>Slide 2</section>
-          </>
-        )}
-      </div>
-    </div>
+    <Deck className="relative h-full w-full overflow-hidden" config={deckConfig} plugins={plugins}>
+      {children || (
+        <>
+          <section>Slide 1</section>
+          <section>Slide 2</section>
+        </>
+      )}
+    </Deck>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@mySlides/api": "workspace:*",
         "@next/mdx": "^16.1.1",
         "@opennextjs/cloudflare": "^1.6.5",
+        "@revealjs/react": "^0.2.1",
         "@tanstack/react-form": "^1.12.3",
         "@tanstack/react-query": "^5.85.5",
         "@trpc/client": "catalog:",
@@ -728,6 +729,8 @@
     "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
+
+    "@revealjs/react": ["@revealjs/react@0.2.1", "", { "peerDependencies": { "react": ">=18", "react-dom": ">=18", "reveal.js": ">=5" } }, "sha512-bEivSQ1W0WpiSUPd4KNLkFGSkdywuno2jjzBHQCO+SN3ChFWP6Y3Z2OLRih3Qeel5k1bwKsSsmr5AMUMA5ZdyQ=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.1.1", "", {}, "sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ=="],
 


### PR DESCRIPTION
## 概要

自前の reveal.js ラッパー(`reveal-presentation.tsx` 内の `new Reveal()` / `initialize()` 実装)を、公式 React ラッパー [`@revealjs/react`](https://revealjs.com/react/) の `<Deck>` コンポーネントへ移行します。

## やったこと

- `@revealjs/react@^0.2.1` を追加し、`reveal-presentation.tsx` の内部実装を `<Deck>` ベースに置き換え
- **公開 API(`children` / `theme` / `transition` / `embedded` / `config`)は完全維持** → 利用側の約12ページと全スライドコンポーネントは無改修
- `<Deck>` は内部で `.reveal` / `.slides` ラッパーを生成し、生の `<section>` を children として受け取れるため、既存スライド構造をそのまま利用

## 設計判断

- **reveal.js 本体は `^5.2.1` のまま据え置き**。ラッパーの peerDeps が `reveal.js >=5` のため、5→6 のメジャーアップに伴う破壊的変更を本 PR から切り離した(必要なら別 PR で対応)
- 型は reveal.js のバージョン差で export が揺れるため、`reveal.js` から直接 import せず `<Deck>` の prop 型から導出
- reveal.js はクライアントで DOM を書き換えるため、**マウント後にのみ `<Deck>` を描画**して hydration mismatch を防止(旧実装が `useEffect` 内初期化で実質クライアント専用だった挙動を踏襲)

## 確認

- `bun run build`: ✅ 成功(静的ページ 37/37 生成)
- `bun run check`(lint + fmt): ✅ エラー0(残る警告は既存の `<img>` 由来で本変更とは無関係)
- ブラウザ確認(localhost:3001):
  - `/better-t-stack` 本番ページ → スライド描画・ナビゲーション正常、console エラーなし
  - `/`(embedded プレビュー = SlideCard)→ 正常、console エラーなし、hydration エラーなし

## 補足 / 注意点

- `@revealjs/react` は現状 **0.2.1(pre-1.0)** と若いため、将来のマイナーアップで API 変更の可能性あり
- ラッパーの同期モデルは「スライド構造の増減時のみ再同期、スライド内コンテンツ更新では再同期しない」仕様。現状の静的スライド構成では問題ないが、動的差し替えを行う場合は要注意
- opennextjs-cloudflare(esbuild)での本番ビルドは未検証 → デプロイ前にプレビュービルドの確認を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)