### PR TITLE
Fix Cloudflare OpenNext build command

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,16 @@
 import createMDX from "@next/mdx";
 import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
+
+const monorepoRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
 const nextConfig: NextConfig = {
   typedRoutes: true,
+  turbopack: {
+    root: monorepoRoot,
+  },
   // reactCompiler: true, // Disabled due to __name esbuild helper conflict with Cloudflare Workers
   devIndicators: process.env.NEXT_PUBLIC_HIDE_DEVTOOLS ? false : undefined,
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "prepare": "vp config",
     "dev": "vp run -r --parallel dev",
     "build": "vp run -r --cache build",
+    "build:cloudflare": "vp run -F @mySlides/db build && vp run -F @mySlides/api build && cd apps/web && bunx opennextjs-cloudflare build",
+    "deploy:cloudflare": "cd apps/web && bunx opennextjs-cloudflare deploy",
     "check-types": "vp run -r --cache check-types",
     "dev:native": "vp run -F native dev",
     "dev:web": "vp run -F web dev",


### PR DESCRIPTION
## Summary
- add a Cloudflare-specific build script that builds workspace packages and runs OpenNext directly
- add a Cloudflare deploy script using the OpenNext Cloudflare CLI
- pin Turbopack root to the monorepo root for Next.js builds

## Verification
- vp check
- bun run build:cloudflare

Note: vp test currently fails before running tests because Vite+ cannot resolve the vitest bin entry from @voidzero-dev/vite-plus-test.