### PR TITLE
fix(web): Vite+ retro スライドの画像をモバイルで見やすく拡大

### DIFF
--- a/apps/web/src/app/vite-plus-retro/slides.mdx
+++ b/apps/web/src/app/vite-plus-retro/slides.mdx
@@ -49,9 +49,9 @@ import {
     style={{
       margin: "0 auto",
       display: "block",
-      width: "auto",
+      width: "1100px",
       height: "auto",
-      maxHeight: "640px",
+      maxHeight: "760px",
       maxWidth: "100%",
       borderRadius: "8px",
     }}
@@ -152,7 +152,7 @@ import {
   style={{
     margin: "1.5rem auto 0",
     display: "block",
-    width: "auto",
+    width: "1600px",
     height: "auto",
     maxWidth: "100%",
     maxHeight: "520px",
@@ -308,10 +308,10 @@ import {
   style={{
     margin: "0 auto 1rem",
     display: "block",
-    width: "auto",
+    width: "1000px",
     height: "auto",
     maxWidth: "100%",
-    maxHeight: "340px",
+    maxHeight: "500px",
     borderRadius: "8px",
   }}
 />
@@ -332,10 +332,10 @@ import {
   style={{
     margin: "0 auto 0.5rem",
     display: "block",
-    width: "auto",
+    width: "600px",
     height: "auto",
     maxWidth: "100%",
-    maxHeight: "580px",
+    maxHeight: "720px",
     borderRadius: "8px",
   }}
 />


### PR DESCRIPTION
## 概要
Vite+ retro スライドをスマホで見たときに、一部の画像が極端に小さく表示される問題を修正します。

## 原因
- このスライドは reveal.js を固定サイズ（1920×1080）で描画し、画面幅に合わせて全体を縮小している。スマホ縦持ちではスライド全体が **約 0.195 倍**まで縮む。
- その上で各画像が `width: "auto"` 指定だったため、Next.js `<Image>` が小さめの最適化ビットマップを配信し、それを実寸描画 → スライド幅の **3 割程度**にしか広がらず、スマホでは潰れて読めなかった（特に PR #135 のスクショ）。

## 対応
`width: "auto"` を画像ごとに明示幅へ変更し、スライド幅いっぱいまで拡大されるようにした（`maxWidth: 100%` / `maxHeight` で上限はガード）。

| 画像 | 変更前 → 変更後 |
|---|---|
| 扇子ツーショ (sensu) | `auto / maxHeight 640px` → `1100px / maxHeight 760px` |
| PR #135 | `auto` → `1600px` |
| PR #220 | `auto / maxHeight 340px` → `1000px / maxHeight 500px` |
| 悪循環ポスター (spiral) | `auto / maxHeight 580px` → `600px / maxHeight 720px` |

## 検証
Chrome DevTools で iPhone 幅(390px)をエミュレートして確認：
- PR #135：判読不能 → タイトル・ブランチ名まで読めるサイズに
- PR #220 / 扇子 / ポスター：いずれも拡大、下の箇条書きも崩れず収まることを確認
- デスクトップ(1440px)でもはみ出しなし・中央揃えを確認

変更は `apps/web/src/app/vite-plus-retro/slides.mdx` の 1 ファイルのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)