### PR TITLE
fix(web): deploy-staging ワークフローを vinext + wrangler に置換

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,9 +24,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NEXT_PUBLIC_R2_BASE_URL: "https://pub-12dea38316b14a799f73d17465eadeb1.r2.dev"
-        run: |
-          bunx opennextjs-cloudflare build
-          bunx opennextjs-cloudflare deploy --env staging
+          NEXT_PUBLIC_BASE_URL: "https://myslides-staging.koutarouhanabusa.workers.dev"
+          NEXT_PUBLIC_SERVER_URL: "https://myslides-server.koutarouhanabusa.workers.dev"
+        run: bun run deploy:staging
       - run: |
           echo "## Staging Preview" >> $GITHUB_STEP_SUMMARY
           echo "https://myslides-staging.koutarouhanabusa.workers.dev" >> $GITHUB_STEP_SUMMARY

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "prebuild": "bun scripts/generate-ogp.tsx",
     "build": "vinext build",
     "start": "vinext start",
-    "deploy": "vinext deploy",
+    "deploy": "bun run build && wrangler deploy",
+    "deploy:staging": "bun run build && wrangler deploy --env staging",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "test:ogp": "vinext build && bun scripts/test-ogp.ts",
     "test:ogp:remote": "bun scripts/test-ogp.ts"


### PR DESCRIPTION
deploy-staging.yml が opennextjs-cloudflare 直叩きのまま残っていて staging push 後の自動デプロイが失敗していた。

- apps/web に deploy:staging スクリプトを追加（build + wrangler deploy --env staging）
- 通常の deploy も bun run build + wrangler deploy に統一
- ワークフローでは bun run deploy:staging を呼ぶだけにし、 NEXT_PUBLIC_BASE_URL / NEXT_PUBLIC_SERVER_URL を build 時に staging URL で渡す（NEXT_PUBLIC_* は build 時に inline されるため、 worker 起動後の wrangler vars に依存せず staging URL がバンドルに焼ける）