### PR TITLE
perf(web): deploy フェーズの redundant ビルドを除去

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,7 +26,9 @@ jobs:
           NEXT_PUBLIC_R2_BASE_URL: "https://pub-12dea38316b14a799f73d17465eadeb1.r2.dev"
           NEXT_PUBLIC_BASE_URL: "https://myslides-staging.koutarouhanabusa.workers.dev"
           NEXT_PUBLIC_SERVER_URL: "https://myslides-server.koutarouhanabusa.workers.dev"
-        run: bun run deploy:staging
+        run: |
+          bun run build
+          bun run deploy:staging
       - run: |
           echo "## Staging Preview" >> $GITHUB_STEP_SUMMARY
           echo "https://myslides-staging.koutarouhanabusa.workers.dev" >> $GITHUB_STEP_SUMMARY

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,8 +9,8 @@
     "prebuild": "bun scripts/generate-ogp.tsx",
     "build": "vinext build",
     "start": "vinext start",
-    "deploy": "bun run build && wrangler deploy",
-    "deploy:staging": "bun run build && wrangler deploy --env staging",
+    "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "test:ogp": "vinext build && bun scripts/test-ogp.ts",
     "test:ogp:remote": "bun scripts/test-ogp.ts"


### PR DESCRIPTION
Cloudflare Workers Builds は build phase と deploy phase が分離していて、 それぞれで bun run build:cloudflare / bun run deploy:cloudflare が走る。 deploy 側に 'bun run build && wrangler deploy' を仕込んでいたため、 deploy phase でもう一度 vinext build が走り 15 秒余分にかかっていた。

実ログから判明 (CW Builds, slide.burio16.com 本番):
  09:42:47 [BUILD]  vinext build 開始
  09:42:59 [BUILD]  完了 (~12s)
  09:43:00 [DEPLOY] bun run build 再実行
  09:43:15 [DEPLOY] vinext build 完了 (~15s) ← 余分
  09:43:16 wrangler deploy 開始
  09:43:23 完了 (~7s)

対応:
- apps/web の deploy / deploy:staging を wrangler deploy のみに変更
- deploy-staging.yml では build を明示的に前置 (GHA は単一 step なので)

なお wrangler deploy 自体は OpenNext より速い:
  Worker bundle: 10,496 KiB → 1,818 KiB (-83%)
  Uploaded:       11.42s    → 5.67s     (-50%)